### PR TITLE
Fixed GUI Placeholders

### DIFF
--- a/src/main/java/me/clip/deluxetags/DeluxeTags.java
+++ b/src/main/java/me/clip/deluxetags/DeluxeTags.java
@@ -279,8 +279,6 @@ public class DeluxeTags extends JavaPlugin {
 			tag = new DeluxeTag(1, "", "", "");
 		}
 
-		String uuid = p.getUniqueId().toString();
-		
 		if (deluxeMode) {
 
 			if (s.contains("%player%")) {


### PR DESCRIPTION
Currently, the identifier tag and description in the DeluxeTags GUI show the wrong identifier and description for all the tags.

This PR fixes that.