### PR TITLE
Added GUI Size and Slots Customisation Options

### DIFF
--- a/src/main/java/me/clip/deluxetags/config/TagConfig.java
+++ b/src/main/java/me/clip/deluxetags/config/TagConfig.java
@@ -66,64 +66,73 @@ public class TagConfig {
       config.set("force_tag_on_join", null);
     }
     config.addDefault("load_tag_on_join", true);
+
     // GUI properties
     config.addDefault("gui.name", "&6Available tags&f: &6%deluxetags_amount%");
     config.addDefault("gui.size", 54);
     config.addDefault("gui.tagSlots", Collections.singletonList("0-35"));
+
     // Tag Select item
     config.addDefault("gui.tag_select_item.material", "NAME_TAG");
     config.addDefault("gui.tag_select_item.data", 0);
     config.addDefault("gui.tag_select_item.displayname", "&6Tag&f: &6%deluxetags_identifier%");
     config.addDefault("gui.tag_select_item.lore",
         Arrays.asList("%deluxetags_tag%", "%deluxetags_description%"));
+
     // Tag Visible item
     config.addDefault("gui.tag_visible_item.material", "NAME_TAG");
     config.addDefault("gui.tag_visible_item.data", 0);
     config.addDefault("gui.tag_visible_item.displayname", "&6Tag&f: &6%deluxetags_identifier%");
     config.addDefault("gui.tag_visible_item.lore",
         Arrays.asList("%deluxetags_tag%", "%deluxetags_description%", "&7You can see this tag but you can't select it!"));
+
     // Divider item
     config.addDefault("gui.divider_item.material", "BLACK_STAINED_GLASS_PANE");
     config.addDefault("gui.divider_item.data", 0);
     config.addDefault("gui.divider_item.displayname", "");
     config.addDefault("gui.divider_item.lore",
         Collections.emptyList());
-    config.addDefault("gui.divider_item.slots", Collections.singletonList("36-44"));
+    addDefaultUnlessAlternativePathExists("gui.divider_item.slots", Collections.singletonList("36-44"), "gui.divider_item.slot");
+
     // Has Tag item
     config.addDefault("gui.has_tag_item.material", "PLAYER_HEAD");
     config.addDefault("gui.has_tag_item.data", 0);
     config.addDefault("gui.has_tag_item.displayname", "&eCurrent tag&f: &6%deluxetags_identifier%");
     config.addDefault("gui.has_tag_item.lore",
         Arrays.asList("%deluxetags_tag%", "Click to remove your current tag"));
-    config.addDefault("gui.has_tag_item.slot", 49);
+    addDefaultUnlessAlternativePathExists("gui.has_tag_item.slot", 49, "gui.has_tag_item.slots");
+
     // No Tag item
     config.addDefault("gui.no_tag_item.material", "PLAYER_HEAD");
     config.addDefault("gui.no_tag_item.data", 0);
     config.addDefault("gui.no_tag_item.displayname", "&cYou don't have a tag set!");
     config.addDefault("gui.no_tag_item.lore",
         Collections.singletonList("&7Click a tag above to select one!"));
-    config.addDefault("gui.no_tag_item.slot", 49);
+    addDefaultUnlessAlternativePathExists("gui.no_tag_item.slot", 49,  "gui.no_tag_item.slots");
+
     // Exit item
     config.addDefault("gui.exit_item.material", "IRON_DOOR");
     config.addDefault("gui.exit_item.data", 0);
     config.addDefault("gui.exit_item.displayname", "&cClick to exit");
     config.addDefault("gui.exit_item.lore",
         Collections.singletonList("&7Exit the tags menu"));
-    config.addDefault("gui.exit_item.slots", Arrays.asList(48, 50));
+    addDefaultUnlessAlternativePathExists("gui.exit_item.slots", Arrays.asList(48, 50), "gui.exit_item.slot");
+
     // Next Page item
     config.addDefault("gui.next_page.material", "PAPER");
     config.addDefault("gui.next_page.data", 0);
     config.addDefault("gui.next_page.displayname", "&6Next page: %page%");
     config.addDefault("gui.next_page.lore",
         Collections.singletonList("&7Move to the next page"));
-    config.addDefault("gui.next_page.slot", 53);
+    addDefaultUnlessAlternativePathExists("gui.next_page.slot", 53, "gui.next_page.slots");
+
     // Previous Page item
     config.addDefault("gui.previous_page.material", "PAPER");
     config.addDefault("gui.previous_page.data", 0);
     config.addDefault("gui.previous_page.displayname", "&6Previous page: %page%");
     config.addDefault("gui.previous_page.lore",
         Collections.singletonList("&7Move to the previous page"));
-    config.addDefault("gui.previous_page.slot", 45);
+    addDefaultUnlessAlternativePathExists("gui.previous_page.slot", 45, "gui.previous_page.slots");
 
     if (!config.contains("deluxetags")) {
       config.set("deluxetags.example.order", 1);
@@ -136,6 +145,18 @@ public class TagConfig {
     plugin.saveConfig();
     plugin.reloadConfig();
     config = plugin.getConfig();
+  }
+
+  /**
+   * Adds config path unless alternative path is set.
+   * @param path path to set
+   * @param value path value
+   * @param alternativePath alternative path that means original path shouldn't be set
+   */
+  private void addDefaultUnlessAlternativePathExists(String path, Object value, String alternativePath) {
+    if (!config.contains(alternativePath)) {
+      config.addDefault(path, value);
+    }
   }
 
   public boolean formatChat() {

--- a/src/main/java/me/clip/deluxetags/config/TagConfig.java
+++ b/src/main/java/me/clip/deluxetags/config/TagConfig.java
@@ -212,8 +212,8 @@ public class TagConfig {
           slots.add(Integer.parseInt(slot));
         }
       }
-    } else {
-      slots.add(config.getInt("gui." + type.name().toLowerCase() + ".slot", 0));
+    } else if (config.contains("gui." + type.name().toLowerCase() + ".slot") && config.isInt("gui." + type.name().toLowerCase() + ".slot")) {
+      slots.add(config.getInt("gui." + type.name().toLowerCase() + ".slot"));
     }
 
     return material == null ? null : new DisplayItem(material, data, displayName, lore, slots);

--- a/src/main/java/me/clip/deluxetags/config/TagConfig.java
+++ b/src/main/java/me/clip/deluxetags/config/TagConfig.java
@@ -14,6 +14,7 @@ import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
 public class TagConfig {
 
@@ -203,7 +204,7 @@ public class TagConfig {
     return config.getInt("gui.size", 54);
   }
 
-  public DisplayItem loadGuiItem(ItemType type) {
+  public DisplayItem loadGuiItem(@NotNull final ItemType type) {
     Material material;
     String displayName;
     List<String> lore;

--- a/src/main/java/me/clip/deluxetags/config/TagConfig.java
+++ b/src/main/java/me/clip/deluxetags/config/TagConfig.java
@@ -1,11 +1,12 @@
 package me.clip.deluxetags.config;
 
 import com.cryptomorin.xseries.XMaterial;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+
+import java.util.*;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import me.clip.deluxetags.DeluxeTags;
 import me.clip.deluxetags.gui.DisplayItem;
 import me.clip.deluxetags.gui.ItemType;
@@ -67,47 +68,66 @@ public class TagConfig {
       config.set("force_tag_on_join", null);
     }
     config.addDefault("load_tag_on_join", true);
+    // GUI properties
     config.addDefault("gui.name", "&6Available tags&f: &6%deluxetags_amount%");
+    config.addDefault("gui.size", 54);
+    config.addDefault("gui.tagSlots", IntStream.rangeClosed(0, 35)
+      .boxed()
+      .collect(Collectors.toList()));
+    // Tag Select item
     config.addDefault("gui.tag_select_item.material", "NAME_TAG");
     config.addDefault("gui.tag_select_item.data", 0);
     config.addDefault("gui.tag_select_item.displayname", "&6Tag&f: &6%deluxetags_identifier%");
     config.addDefault("gui.tag_select_item.lore",
         Arrays.asList("%deluxetags_tag%", "%deluxetags_description%"));
+    // Tag Visible item
     config.addDefault("gui.tag_visible_item.material", "NAME_TAG");
     config.addDefault("gui.tag_visible_item.data", 0);
     config.addDefault("gui.tag_visible_item.displayname", "&6Tag&f: &6%deluxetags_identifier%");
     config.addDefault("gui.tag_visible_item.lore",
         Arrays.asList("%deluxetags_tag%", "%deluxetags_description%", "&7You can see this tag but you can't select it!"));
+    // Divider item
     config.addDefault("gui.divider_item.material", "BLACK_STAINED_GLASS_PANE");
     config.addDefault("gui.divider_item.data", 0);
     config.addDefault("gui.divider_item.displayname", "");
     config.addDefault("gui.divider_item.lore",
         Collections.emptyList());
+    config.addDefault("gui.divider_item.slots", Arrays.asList(36, 37, 38, 39, 40, 41, 42, 43, 44, 45));
+    // Has Tag item
     config.addDefault("gui.has_tag_item.material", "PLAYER_HEAD");
     config.addDefault("gui.has_tag_item.data", 0);
     config.addDefault("gui.has_tag_item.displayname", "&eCurrent tag&f: &6%deluxetags_identifier%");
     config.addDefault("gui.has_tag_item.lore",
         Arrays.asList("%deluxetags_tag%", "Click to remove your current tag"));
+    config.addDefault("gui.has_tag_item.slot", 49);
+    // No Tag item
     config.addDefault("gui.no_tag_item.material", "PLAYER_HEAD");
     config.addDefault("gui.no_tag_item.data", 0);
     config.addDefault("gui.no_tag_item.displayname", "&cYou don't have a tag set!");
     config.addDefault("gui.no_tag_item.lore",
         Collections.singletonList("&7Click a tag above to select one!"));
+    config.addDefault("gui.no_tag_item.slot", 49);
+    // Exit item
     config.addDefault("gui.exit_item.material", "IRON_DOOR");
     config.addDefault("gui.exit_item.data", 0);
     config.addDefault("gui.exit_item.displayname", "&cClick to exit");
     config.addDefault("gui.exit_item.lore",
         Collections.singletonList("&7Exit the tags menu"));
+    config.addDefault("gui.exit_item.slots", Arrays.asList(48, 50));
+    // Next Page item
     config.addDefault("gui.next_page.material", "PAPER");
     config.addDefault("gui.next_page.data", 0);
     config.addDefault("gui.next_page.displayname", "&6Next page: %page%");
     config.addDefault("gui.next_page.lore",
         Collections.singletonList("&7Move to the next page"));
+    config.addDefault("gui.next_page.slot", 53);
+    // Previous Page item
     config.addDefault("gui.previous_page.material", "PAPER");
     config.addDefault("gui.previous_page.data", 0);
     config.addDefault("gui.previous_page.displayname", "&6Previous page: %page%");
     config.addDefault("gui.previous_page.lore",
         Collections.singletonList("&7Move to the previous page"));
+    config.addDefault("gui.previous_page.slot", 45);
 
     if (!config.contains("deluxetags")) {
       config.set("deluxetags.example.order", 1);
@@ -151,15 +171,22 @@ public class TagConfig {
     return config.getBoolean("force_tags");
   }
 
-  public String loadMenuName() {
+  public String getMenuName() {
     return config.getString("gui.name", "&6Available tags&f: &6%deluxetags_amount%");
+  }
+
+  public int getMenuSize() {
+    return config.getInt("gui.size", 54);
   }
 
   public DisplayItem loadGuiItem(ItemType type) {
     Material material;
     String displayName;
     List<String> lore;
+    List<Integer> slots;
     short data;
+
+    String basePath = "gui." + type.name().toLowerCase();
 
     try {
       material = XMaterial.matchXMaterial(config.getString("gui." + type.name().toLowerCase() + ".material").toUpperCase()).get().parseMaterial();
@@ -176,7 +203,24 @@ public class TagConfig {
     displayName = config.getString("gui." + type.name().toLowerCase() + ".displayname");
     lore = config.getStringList("gui." + type.name().toLowerCase() + ".lore");
 
-    return material == null ? null : new DisplayItem(material, data, displayName, lore);
+    slots = new ArrayList<>();
+    if (config.contains("gui." + type.name().toLowerCase() + ".slots") && config.isList("gui." + type.name().toLowerCase() + ".slots")) {
+      List<String> confSlots = config.getStringList("gui." + type.name().toLowerCase() + ".slots");
+      for (String slot : confSlots) {
+        String[] values = slot.split("-", 2);
+        if (values.length == 2) {
+          for (int i = Integer.parseInt(values[0]); i <= Integer.parseInt(values[1]); i++) {
+            slots.add(i);
+          }
+        } else {
+          slots.add(Integer.parseInt(slot));
+        }
+      }
+    } else {
+      slots.add(config.getInt("gui." + type.name().toLowerCase() + ".slot", 0));
+    }
+
+    return material == null ? null : new DisplayItem(material, data, displayName, lore, slots);
   }
 
   public int loadTags() {

--- a/src/main/java/me/clip/deluxetags/config/TagConfig.java
+++ b/src/main/java/me/clip/deluxetags/config/TagConfig.java
@@ -9,9 +9,11 @@ import me.clip.deluxetags.DeluxeTags;
 import me.clip.deluxetags.gui.DisplayItem;
 import me.clip.deluxetags.gui.ItemType;
 import me.clip.deluxetags.tags.DeluxeTag;
+import me.clip.deluxetags.utils.ItemUtils;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.inventory.ItemStack;
 
 public class TagConfig {
 
@@ -70,7 +72,7 @@ public class TagConfig {
     // GUI properties
     config.addDefault("gui.name", "&6Available tags&f: &6%deluxetags_amount%");
     config.addDefault("gui.size", 54);
-    config.addDefault("gui.tagSlots", Collections.singletonList("0-35"));
+    config.addDefault("gui.tag_slots", Collections.singletonList("0-35"));
 
     // Tag Select item
     config.addDefault("gui.tag_select_item.material", "NAME_TAG");
@@ -188,6 +190,11 @@ public class TagConfig {
     return config.getBoolean("force_tags");
   }
 
+  public List<Integer> getTagSlots() {
+    // Conforms to existing code style but isn't as efficient as it could be due to processing on each call
+    return loadSlots("gui.tag_slots", "gui.tag_slots");
+  }
+
   public String getMenuName() {
     return config.getString("gui.name", "&6Available tags&f: &6%deluxetags_amount%");
   }
@@ -206,38 +213,25 @@ public class TagConfig {
     String basePath = "gui." + type.name().toLowerCase();
 
     try {
-      material = XMaterial.matchXMaterial(config.getString("gui." + type.name().toLowerCase() + ".material").toUpperCase()).get().parseMaterial();
+      material = XMaterial.matchXMaterial(config.getString(basePath + ".material").toUpperCase()).get().parseMaterial();
     } catch (Exception e) {
       material = type.getFallbackMaterial();
     }
 
     try {
-      data = Short.parseShort(config.getString("gui." + type.name().toLowerCase() + ".data", "0"));
+      data = Short.parseShort(config.getString(basePath + ".data", "0"));
     } catch (Exception e) {
       data = 0;
     }
 
-    displayName = config.getString("gui." + type.name().toLowerCase() + ".displayname");
-    lore = config.getStringList("gui." + type.name().toLowerCase() + ".lore");
+    displayName = config.getString(basePath + ".displayname");
+    lore = config.getStringList(basePath + ".lore");
 
-    slots = new ArrayList<>();
-    if (config.contains("gui." + type.name().toLowerCase() + ".slots") && config.isList("gui." + type.name().toLowerCase() + ".slots")) {
-      List<String> confSlots = config.getStringList("gui." + type.name().toLowerCase() + ".slots");
-      for (String slot : confSlots) {
-        String[] values = slot.split("-", 2);
-        if (values.length == 2) {
-          for (int i = Integer.parseInt(values[0]); i <= Integer.parseInt(values[1]); i++) {
-            slots.add(i);
-          }
-        } else {
-          slots.add(Integer.parseInt(slot));
-        }
-      }
-    } else if (config.contains("gui." + type.name().toLowerCase() + ".slot") && config.isInt("gui." + type.name().toLowerCase() + ".slot")) {
-      slots.add(config.getInt("gui." + type.name().toLowerCase() + ".slot"));
-    }
+    slots = loadSlots(basePath + ".slots", basePath + ".slot");
 
-    return material == null ? null : new DisplayItem(material, data, displayName, lore, slots);
+    ItemStack itemStack = ItemUtils.createItem(material, data, displayName, lore);
+
+    return material == null ? null : new DisplayItem(type, itemStack, slots);
   }
 
   public int loadTags() {
@@ -300,5 +294,26 @@ public class TagConfig {
   public void removeTag(String identifier) {
     config.set("deluxetags." + identifier, null);
     plugin.saveConfig();
+  }
+
+  private List<Integer> loadSlots(String slotsPath, String slotPath) {
+    List<Integer> slotsList = new ArrayList<>();
+    if (config.contains(slotsPath) && config.isList(slotsPath)) {
+      List<String> confSlots = config.getStringList(slotsPath);
+      for (String slot : confSlots) {
+        String[] values = slot.split("-", 2);
+        if (values.length == 2) {
+          for (int i = Integer.parseInt(values[0]); i <= Integer.parseInt(values[1]); i++) {
+            slotsList.add(i);
+          }
+        } else {
+          slotsList.add(Integer.parseInt(slot));
+        }
+      }
+    } else if (config.contains(slotPath) && config.isInt(slotPath)) {
+      slotsList.add(config.getInt(slotPath));
+    }
+
+    return slotsList;
   }
 }

--- a/src/main/java/me/clip/deluxetags/config/TagConfig.java
+++ b/src/main/java/me/clip/deluxetags/config/TagConfig.java
@@ -4,8 +4,6 @@ import com.cryptomorin.xseries.XMaterial;
 
 import java.util.*;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import me.clip.deluxetags.DeluxeTags;
 import me.clip.deluxetags.gui.DisplayItem;
@@ -71,9 +69,7 @@ public class TagConfig {
     // GUI properties
     config.addDefault("gui.name", "&6Available tags&f: &6%deluxetags_amount%");
     config.addDefault("gui.size", 54);
-    config.addDefault("gui.tagSlots", IntStream.rangeClosed(0, 35)
-      .boxed()
-      .collect(Collectors.toList()));
+    config.addDefault("gui.tagSlots", Collections.singletonList("0-35"));
     // Tag Select item
     config.addDefault("gui.tag_select_item.material", "NAME_TAG");
     config.addDefault("gui.tag_select_item.data", 0);
@@ -92,7 +88,7 @@ public class TagConfig {
     config.addDefault("gui.divider_item.displayname", "");
     config.addDefault("gui.divider_item.lore",
         Collections.emptyList());
-    config.addDefault("gui.divider_item.slots", Arrays.asList(36, 37, 38, 39, 40, 41, 42, 43, 44));
+    config.addDefault("gui.divider_item.slots", Collections.singletonList("36-44"));
     // Has Tag item
     config.addDefault("gui.has_tag_item.material", "PLAYER_HEAD");
     config.addDefault("gui.has_tag_item.data", 0);

--- a/src/main/java/me/clip/deluxetags/config/TagConfig.java
+++ b/src/main/java/me/clip/deluxetags/config/TagConfig.java
@@ -92,7 +92,7 @@ public class TagConfig {
     config.addDefault("gui.divider_item.displayname", "");
     config.addDefault("gui.divider_item.lore",
         Collections.emptyList());
-    config.addDefault("gui.divider_item.slots", Arrays.asList(36, 37, 38, 39, 40, 41, 42, 43, 44, 45));
+    config.addDefault("gui.divider_item.slots", Arrays.asList(36, 37, 38, 39, 40, 41, 42, 43, 44));
     // Has Tag item
     config.addDefault("gui.has_tag_item.material", "PLAYER_HEAD");
     config.addDefault("gui.has_tag_item.data", 0);

--- a/src/main/java/me/clip/deluxetags/gui/DisplayItem.java
+++ b/src/main/java/me/clip/deluxetags/gui/DisplayItem.java
@@ -7,6 +7,7 @@ import me.clip.deluxetags.utils.ItemUtils;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
 
 public class DisplayItem {
 
@@ -14,22 +15,21 @@ public class DisplayItem {
 	private ItemStack itemStack;
 	private List<Integer> slots;
 
-	public DisplayItem(ItemType type, ItemStack itemStack, List<Integer> slots) {
+	public DisplayItem(@NotNull final ItemType type, @NotNull final ItemStack itemStack, @NotNull final List<Integer> slots) {
 		this.type = type;
 		this.itemStack = itemStack;
 		this.slots = slots;
 	}
 
-	public DisplayItem(DisplayItem displayItem) {
-		ItemStack cloned = displayItem.getItemStack() == null ? null : displayItem.getItemStack().clone();
-		List<Integer> slotsCopy = displayItem.getSlots() == null ? null : new ArrayList<>(displayItem.getSlots());
-
-		this.type = displayItem.getType();
-		this.itemStack = cloned;
-		this.slots = slotsCopy;
+	public DisplayItem(@NotNull final DisplayItem displayItem) {
+		this(
+			displayItem.getType(),
+			displayItem.getItemStack().clone(),
+			new ArrayList<>(displayItem.getSlots())
+		);
 	}
 
-	public ItemType getType() {
+	public @NotNull ItemType getType() {
 		return type;
 	}
 

--- a/src/main/java/me/clip/deluxetags/gui/DisplayItem.java
+++ b/src/main/java/me/clip/deluxetags/gui/DisplayItem.java
@@ -9,12 +9,14 @@ public class DisplayItem {
 	private short data;
 	private String name;
 	private List<String> lore;
+	private List<Integer> slots;
 
-	public DisplayItem(Material material, short data, String name, List<String> lore) {
+	public DisplayItem(Material material, short data, String name, List<String> lore, List<Integer> slots) {
 		this.setMaterial(material);
 		this.setData(data);
 		this.setName(name);
 		this.setLore(lore);
+		this.setSlots(slots);
 	}
 
 	public Material getMaterial() {
@@ -48,5 +50,12 @@ public class DisplayItem {
 	public void setLore(List<String> lore) {
 		this.lore = lore;
 	}
-	
+
+	public List<Integer> getSlots() {
+		return slots;
+	}
+
+	public void setSlots(List<Integer> slots) {
+		this.slots = slots;
+	}
 }

--- a/src/main/java/me/clip/deluxetags/gui/DisplayItem.java
+++ b/src/main/java/me/clip/deluxetags/gui/DisplayItem.java
@@ -3,7 +3,6 @@ package me.clip.deluxetags.gui;
 import java.util.ArrayList;
 import java.util.List;
 
-import me.clip.deluxetags.utils.ItemUtils;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -37,41 +36,36 @@ public class DisplayItem {
 		this.type = type;
 	}
 
-	public ItemStack getItemStack() {
+	public @NotNull ItemStack getItemStack() {
 		return itemStack;
 	}
 
-	public void setItemStack(ItemStack itemStack) {
+	public void setItemStack(@NotNull final ItemStack itemStack) {
 		this.itemStack = itemStack;
 	}
 
-	public Material getMaterial() {
-		return this.itemStack != null ? this.itemStack.getType() : null;
+	public @NotNull Material getMaterial() {
+		return this.itemStack.getType();
 	}
 
-	public void setMaterial(Material material) {
-		if (this.itemStack != null) this.itemStack.setType(material);
+	public void setMaterial(@NotNull final Material material) {
+		this.itemStack.setType(material);
 	}
 
 	public short getData() {
-		return this.itemStack != null ? this.itemStack.getDurability() : 0;
+		return this.itemStack.getDurability();
 	}
 
 	public void setData(short data) {
-		if (this.itemStack != null) this.itemStack.setDurability(data);
+		this.itemStack.setDurability(data);
 	}
 
 	public String getName() {
-		if (this.itemStack == null) return null;
-
 		ItemMeta itemMeta = this.itemStack.getItemMeta();
-
 		return itemMeta != null ? itemMeta.getDisplayName() : null;
 	}
 
 	public void setName(String name) {
-		if (this.itemStack == null) return;
-
 		ItemMeta itemMeta = this.itemStack.getItemMeta();
 
 		if (itemMeta != null) {
@@ -82,16 +76,12 @@ public class DisplayItem {
 	}
 
 	public List<String> getLore() {
-		if (this.itemStack == null) return null;
-
 		ItemMeta itemMeta = this.itemStack.getItemMeta();
 
 		return itemMeta != null ? itemMeta.getLore() : null;
 	}
 
 	public void setLore(List<String> lore) {
-		if (this.itemStack == null) return;
-
 		ItemMeta itemMeta = this.itemStack.getItemMeta();
 
 		if (itemMeta != null) {

--- a/src/main/java/me/clip/deluxetags/gui/DisplayItem.java
+++ b/src/main/java/me/clip/deluxetags/gui/DisplayItem.java
@@ -1,54 +1,109 @@
 package me.clip.deluxetags.gui;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import me.clip.deluxetags.utils.ItemUtils;
 import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public class DisplayItem {
 
-	private Material material;
-	private short data;
-	private String name;
-	private List<String> lore;
+	private ItemType type;
+	private ItemStack itemStack;
 	private List<Integer> slots;
 
+	public DisplayItem(ItemType type, ItemStack itemStack, List<Integer> slots) {
+		this.type = type;
+		this.itemStack = itemStack;
+		this.slots = slots;
+	}
+
+	public DisplayItem(DisplayItem displayItem) {
+		ItemStack cloned = displayItem.getItemStack() == null ? null : displayItem.getItemStack().clone();
+		List<Integer> slotsCopy = displayItem.getSlots() == null ? null : new ArrayList<>(displayItem.getSlots());
+
+		this.type = displayItem.getType();
+		this.itemStack = cloned;
+		this.slots = slotsCopy;
+	}
+
+	@Deprecated
 	public DisplayItem(Material material, short data, String name, List<String> lore, List<Integer> slots) {
-		this.setMaterial(material);
-		this.setData(data);
-		this.setName(name);
-		this.setLore(lore);
-		this.setSlots(slots);
+		this(ItemType.UNKNOWN, ItemUtils.createItem(material, data, name, lore), slots);
+	}
+
+	public ItemType getType() {
+		return type;
+	}
+
+	public void setType(ItemType type) {
+		this.type = type;
+	}
+
+	public ItemStack getItemStack() {
+		return itemStack;
+	}
+
+	public void setItemStack(ItemStack itemStack) {
+		this.itemStack = itemStack;
 	}
 
 	public Material getMaterial() {
-		return material;
+		return this.itemStack != null ? this.itemStack.getType() : null;
 	}
 
 	public void setMaterial(Material material) {
-		this.material = material;
+		if (this.itemStack != null) this.itemStack.setType(material);
 	}
 
 	public short getData() {
-		return data;
+		return this.itemStack != null ? this.itemStack.getDurability() : 0;
 	}
 
 	public void setData(short data) {
-		this.data = data;
+		if (this.itemStack != null) this.itemStack.setDurability(data);
 	}
 
 	public String getName() {
-		return name;
+		if (this.itemStack == null) return null;
+
+		ItemMeta itemMeta = this.itemStack.getItemMeta();
+
+		return itemMeta != null ? itemMeta.getDisplayName() : null;
 	}
 
 	public void setName(String name) {
-		this.name = name;
+		if (this.itemStack == null) return;
+
+		ItemMeta itemMeta = this.itemStack.getItemMeta();
+
+		if (itemMeta != null) {
+			itemMeta.setDisplayName(name);
+		}
+
+		this.itemStack.setItemMeta(itemMeta);
 	}
 
 	public List<String> getLore() {
-		return lore;
+		if (this.itemStack == null) return null;
+
+		ItemMeta itemMeta = this.itemStack.getItemMeta();
+
+		return itemMeta != null ? itemMeta.getLore() : null;
 	}
 
 	public void setLore(List<String> lore) {
-		this.lore = lore;
+		if (this.itemStack == null) return;
+
+		ItemMeta itemMeta = this.itemStack.getItemMeta();
+
+		if (itemMeta != null) {
+			itemMeta.setLore(lore);
+		}
+
+		this.itemStack.setItemMeta(itemMeta);
 	}
 
 	public List<Integer> getSlots() {

--- a/src/main/java/me/clip/deluxetags/gui/DisplayItem.java
+++ b/src/main/java/me/clip/deluxetags/gui/DisplayItem.java
@@ -29,11 +29,6 @@ public class DisplayItem {
 		this.slots = slotsCopy;
 	}
 
-	@Deprecated
-	public DisplayItem(Material material, short data, String name, List<String> lore, List<Integer> slots) {
-		this(ItemType.UNKNOWN, ItemUtils.createItem(material, data, name, lore), slots);
-	}
-
 	public ItemType getType() {
 		return type;
 	}

--- a/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
+++ b/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
@@ -216,9 +216,7 @@ public class GUIHandler implements Listener {
             plugin.setPlaceholders(p, replacePageNumbers(options.getDividerItem().getName(), page, hasNextPage), null),
             processLore(options.getDividerItem().getLore(), p, null, page, hasNextPage)
         );
-        for (int b = 36; b < 45; b++) {
-            gui.setItem(b, divider);
-        }
+        gui.setItem(options.getDividerItem().getSlots(), divider);
 
         final DeluxeTag currentTag = plugin.getTagsHandler().getPlayerActiveTag(p);
         DisplayItem currentTagItem;
@@ -236,7 +234,7 @@ public class GUIHandler implements Listener {
             plugin.setPlaceholders(p, replacePageNumbers(currentTagItem.getName(), page, hasNextPage), null),
             processLore(currentTagItem.getLore(), p, null, page, hasNextPage)
         );
-        gui.setItem(49, info);
+        gui.setItem(currentTagItem.getSlots(), info);
 
         ItemStack exit = TagGUI.createItem(
             options.getExitItem().getMaterial(),
@@ -245,8 +243,7 @@ public class GUIHandler implements Listener {
             plugin.setPlaceholders(p, replacePageNumbers(options.getExitItem().getName(), page, hasNextPage), null),
             processLore(options.getExitItem().getLore(), p, null, page, hasNextPage)
         );
-        gui.setItem(48, exit);
-        gui.setItem(50, exit);
+        gui.setItem(options.getExitItem().getSlots(), exit);
 
         if (page > 1) {
             ItemStack previousPage = TagGUI.createItem(
@@ -256,7 +253,7 @@ public class GUIHandler implements Listener {
                 plugin.setPlaceholders(p, replacePageNumbers(options.getPreviousPageItem().getName().replace("%page%", String.valueOf(page-1)), page, hasNextPage), null),
                 processLore(options.getPreviousPageItem().getLore(), p, null, page, hasNextPage)
             );
-            gui.setItem(45, previousPage);
+            gui.setItem(options.getPreviousPageItem().getSlots(), previousPage);
         }
 
         if (hasNextPage) {
@@ -267,7 +264,7 @@ public class GUIHandler implements Listener {
                 plugin.setPlaceholders(p, replacePageNumbers(options.getNextPageItem().getName().replace("%page%", String.valueOf(page+1)), page, true), null),
                 processLore(options.getNextPageItem().getLore(), p, null, page, true)
             );
-            gui.setItem(53, nextPage);
+            gui.setItem(options.getNextPageItem().getSlots(), nextPage);
         }
 
         gui.setPage(page);

--- a/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
+++ b/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
@@ -1,14 +1,12 @@
 package me.clip.deluxetags.gui;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import me.clip.deluxetags.DeluxeTags;
 import me.clip.deluxetags.config.Lang;
 import me.clip.deluxetags.tags.DeluxeTag;
 import me.clip.deluxetags.utils.MsgUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -16,6 +14,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public class GUIHandler implements Listener {
 
@@ -53,83 +52,99 @@ public class GUIHandler implements Listener {
 
         int slot = e.getRawSlot();
 
-        if (slot < 36) {
-            Map<Integer, String> tags;
-            try {
-                tags = gui.getTags();
-            } catch (NullPointerException ex) {
+        ItemType clickedItemType = gui.getClickedItemType(slot);
+        switch (clickedItemType) {
+            case UNKNOWN:
+                break;
+            case EXIT_ITEM:
                 TagGUI.close(p);
                 p.closeInventory();
-                return;
-            }
-
-            if (tags.isEmpty()) {
+                break;
+            case NO_TAG_ITEM:
                 TagGUI.close(p);
                 p.closeInventory();
-                return;
-            }
+                break;
+            case NEXT_PAGE:
+                openMenu(p, gui.getPage()+1);
+                break;
+            case DIVIDER_ITEM:
+                break;
+            case HAS_TAG_ITEM:
+                final DeluxeTag currentTag = plugin.getTagsHandler().getPlayerActiveTag(p);
+                if (currentTag == null || currentTag.getDisplayTag(p).isEmpty() || plugin.getTagsHandler().isUsingDefaultTag(p) || plugin.getTagsHandler().isUsingForcedTag(p)) {
+                    p.updateInventory();
+                    return;
+                }
 
-            String id = tags.get(slot);
-            if (id == null || id.isEmpty()) {
                 TagGUI.close(p);
                 p.closeInventory();
-                return;
-            }
 
-            DeluxeTag tag = plugin.getTagsHandler().getTagByIdentifier(id);
-            if (tag == null) {
-                return;
-            }
+                plugin.getTagsHandler().setPlayerTag(p, plugin.getDummyTag());
+                plugin.removeSavedTag(p.getUniqueId().toString());
 
-            if (!p.hasPermission(tag.getPermission())) {
-                sms(p, Lang.CMD_NO_PERMS.getConfigValue(new String[]{
-                    "deluxetags.tag." + id
-                }));
-                TagGUI.close(p);
-                p.closeInventory();
-                return;
-            }
-
-            if (!plugin.getTagsHandler().setPlayerTag(p, tag)) {
-                return;
-            }
-
-            TagGUI.close(p);
-            p.closeInventory();
-
-            tag = plugin.getTagsHandler().getPlayerActiveTag(p);
-            final String displayName = tag == null ? "" : tag.getDisplayTag(p);
-
-            sms(p, Lang.GUI_TAG_SELECTED.getConfigValue(new String[]{id, displayName}));
-
-            plugin.saveTagIdentifier(p.getUniqueId().toString(), id);
-
-        } else if (slot == 48 || slot == 50) {
-            TagGUI.close(p);
-            p.closeInventory();
-
-        } else if (slot == 49) {
-            final DeluxeTag tag = plugin.getTagsHandler().getPlayerActiveTag(p);
-            if (tag == null || tag.getDisplayTag(p).isEmpty() || plugin.getTagsHandler().isUsingDefaultTag(p) || plugin.getTagsHandler().isUsingForcedTag(p)) {
+                sms(p, Lang.GUI_TAG_DISABLED.getConfigValue(null));
                 p.updateInventory();
-                return;
-            }
+                break;
+            case PREVIOUS_PAGE:
+                openMenu(p, gui.getPage()-1);
+                break;
+            case TAG_SELECT_ITEM:
+                Map<Integer, String> tags;
+                try {
+                    tags = gui.getTags();
+                } catch (NullPointerException ex) {
+                    TagGUI.close(p);
+                    p.closeInventory();
+                    return;
+                }
 
-            TagGUI.close(p);
-            p.closeInventory();
+                if (tags.isEmpty()) {
+                    TagGUI.close(p);
+                    p.closeInventory();
+                    return;
+                }
 
-            plugin.getTagsHandler().setPlayerTag(p, plugin.getDummyTag());
-            plugin.removeSavedTag(p.getUniqueId().toString());
+                String id = tags.get(slot);
+                if (id == null || id.isEmpty()) {
+                    TagGUI.close(p);
+                    p.closeInventory();
+                    return;
+                }
 
-            sms(p, Lang.GUI_TAG_DISABLED.getConfigValue(null));
-            p.updateInventory();
+                DeluxeTag selectedTag = plugin.getTagsHandler().getTagByIdentifier(id);
+                if (selectedTag == null) {
+                    return;
+                }
 
-        } else if (slot == 45) {
-            openMenu(p, gui.getPage()-1);
+                if (!p.hasPermission(selectedTag.getPermission())) {
+                    sms(p, Lang.CMD_NO_PERMS.getConfigValue(new String[]{
+                      "deluxetags.tag." + id
+                    }));
+                    TagGUI.close(p);
+                    p.closeInventory();
+                    return;
+                }
 
-        } else if (slot == 53) {
-            openMenu(p, gui.getPage()+1);
+                if (!plugin.getTagsHandler().setPlayerTag(p, selectedTag)) {
+                    return;
+                }
+
+                TagGUI.close(p);
+                p.closeInventory();
+
+                selectedTag = plugin.getTagsHandler().getPlayerActiveTag(p);
+                final String displayName = selectedTag == null ? "" : selectedTag.getDisplayTag(p);
+
+                sms(p, Lang.GUI_TAG_SELECTED.getConfigValue(new String[]{id, displayName}));
+
+                plugin.saveTagIdentifier(p.getUniqueId().toString(), id);
+                break;
+            case TAG_VISIBLE_ITEM:
+                break;
+            default:
+                break;
         }
+
     }
 
     @EventHandler
@@ -152,7 +167,9 @@ public class GUIHandler implements Listener {
 
         GUIOptions options = plugin.getGuiOptions();
 
-        int pages = (int) Math.ceil(ids.size() / 36d);
+        List<Integer> tagSlots = options.getTagSlots();
+
+        int pages = (int) Math.ceil(ids.size() / (double) tagSlots.size());
         boolean hasNextPage = page < pages;
 
         String title = options.getMenuName();
@@ -161,63 +178,55 @@ public class GUIHandler implements Listener {
             title = title.substring(0, 31);
         }
 
-        int slots = options.getMenuSize();
+        int menuSlots = options.getMenuSize();
 
-        TagGUI gui = new TagGUI(title, page).setSlots(slots);
+        TagGUI gui = new TagGUI(title, page).setSlots(menuSlots);
 
         if (page > 1 && page <= pages) {
-            ids = ids.subList((36 * page) - 36, ids.size());
+            ids = ids.subList((tagSlots.size() * page) - tagSlots.size(), ids.size());
         }
 
-        int slot = 0;
+        int idIndex = 0;
         Map<Integer, String> tags = new HashMap<>();
-        for (String id : ids) {
-            if (slot >= 36) {
+        for (int tagSlot: tagSlots) {
+            if (idIndex >= ids.size()) {
                 break;
             }
 
-            tags.put(slot, id);
+            String id = ids.get(idIndex);
+
+            tags.put(tagSlot, id);
             DeluxeTag tag = plugin.getTagsHandler().getTagByIdentifier(id);
             if (tag == null) {
                 tag = plugin.getDummyTag();
             }
 
-            if (tag.hasPermissionToUse(p)) {
-                gui.setItem(
-                    slot,
-                    TagGUI.createItem(
-                        options.getTagSelectItem().getMaterial(),
-                        options.getTagSelectItem().getData(),
-                        1,
-                        plugin.setPlaceholders(p, replacePageNumbers(options.getTagSelectItem().getName(), page, hasNextPage), tag),
-                        processLore(options.getTagSelectItem().getLore(), p, tag, page, hasNextPage)
-                    )
-                );
-            } else {
-                gui.setItem(
-                    slot,
-                    TagGUI.createItem(
-                        options.getTagVisibleItem().getMaterial(),
-                        options.getTagVisibleItem().getData(),
-                        1,
-                        plugin.setPlaceholders(p, replacePageNumbers(options.getTagVisibleItem().getName(), page, hasNextPage), tag),
-                        processLore(options.getTagVisibleItem().getLore(), p, tag, page, hasNextPage)
-                    )
-                );
+            // Adds Tag Item to Menu
+            DisplayItem tagDisplayItem = new DisplayItem(tag.hasPermissionToUse(p) ? options.getTagSelectItem() : options.getTagVisibleItem());
+            ItemMeta tagItemMeta = tagDisplayItem.getItemStack().getItemMeta();
+            if (tagItemMeta != null) {
+                tagItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(tagDisplayItem.getName(), page, hasNextPage), tag));
+                tagItemMeta.setLore(processLore(tagDisplayItem.getLore(), p, tag, page, hasNextPage));
+                tagDisplayItem.getItemStack().setItemMeta(tagItemMeta);
             }
-            slot++;
+            tagDisplayItem.setSlots(Collections.singletonList(tagSlot));
+            gui.addDisplayItem(tagDisplayItem);
+
+            idIndex++;
         }
         gui.setTags(tags);
 
-        ItemStack divider = TagGUI.createItem(
-            options.getDividerItem().getMaterial(),
-            options.getDividerItem().getData(),
-            1,
-            plugin.setPlaceholders(p, replacePageNumbers(options.getDividerItem().getName(), page, hasNextPage), null),
-            processLore(options.getDividerItem().getLore(), p, null, page, hasNextPage)
-        );
-        gui.setItem(options.getDividerItem().getSlots(), divider);
+        // Adds Divider Item to Menu
+        DisplayItem dividerDisplayItem = new DisplayItem(options.getDividerItem());
+        ItemMeta dividerItemMeta = dividerDisplayItem.getItemStack().getItemMeta();
+        if (dividerItemMeta != null) {
+            dividerItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(dividerDisplayItem.getName(), page, hasNextPage), null));
+            dividerItemMeta.setLore(processLore(dividerDisplayItem.getLore(), p, null, page, hasNextPage));
+            dividerDisplayItem.getItemStack().setItemMeta(dividerItemMeta);
+        }
+        gui.addDisplayItem(dividerDisplayItem);
 
+        // Gets Tag Item that represents Player's tag status (Tag equipped or not equipped)
         final DeluxeTag currentTag = plugin.getTagsHandler().getPlayerActiveTag(p);
         DisplayItem currentTagItem;
 
@@ -227,44 +236,48 @@ public class GUIHandler implements Listener {
             currentTagItem = options.getHasTagItem();
         }
 
-        ItemStack info = TagGUI.createItem(
-            currentTagItem.getMaterial(),
-            currentTagItem.getData(),
-            1,
-            plugin.setPlaceholders(p, replacePageNumbers(currentTagItem.getName(), page, hasNextPage), null),
-            processLore(currentTagItem.getLore(), p, null, page, hasNextPage)
-        );
-        gui.setItem(currentTagItem.getSlots(), info);
+        // Adds Info Item to Menu
+        DisplayItem infoDisplayItem = new DisplayItem(currentTagItem);
+        ItemMeta infoItemMeta = infoDisplayItem.getItemStack().getItemMeta();
+        if (infoItemMeta != null) {
+            infoItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(infoDisplayItem.getName(), page, hasNextPage), null));
+            infoItemMeta.setLore(processLore(infoDisplayItem.getLore(), p, null, page, hasNextPage));
+            infoDisplayItem.getItemStack().setItemMeta(infoItemMeta);
+        }
+        gui.addDisplayItem(infoDisplayItem);
 
-        ItemStack exit = TagGUI.createItem(
-            options.getExitItem().getMaterial(),
-            options.getExitItem().getData(),
-            1,
-            plugin.setPlaceholders(p, replacePageNumbers(options.getExitItem().getName(), page, hasNextPage), null),
-            processLore(options.getExitItem().getLore(), p, null, page, hasNextPage)
-        );
-        gui.setItem(options.getExitItem().getSlots(), exit);
+        // Adds Exit Item to Menu
+        DisplayItem exitDisplayItem = new DisplayItem(options.getExitItem());
+        ItemMeta exitItemMeta = dividerDisplayItem.getItemStack().getItemMeta();
+        if (exitItemMeta != null) {
+            exitItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(exitDisplayItem.getName(), page, hasNextPage), null));
+            exitItemMeta.setLore(processLore(exitDisplayItem.getLore(), p, null, page, hasNextPage));
+            exitDisplayItem.getItemStack().setItemMeta(exitItemMeta);
+        }
+        gui.addDisplayItem(exitDisplayItem);
 
         if (page > 1) {
-            ItemStack previousPage = TagGUI.createItem(
-                options.getPreviousPageItem().getMaterial(),
-                options.getPreviousPageItem().getData(),
-                1,
-                plugin.setPlaceholders(p, replacePageNumbers(options.getPreviousPageItem().getName().replace("%page%", String.valueOf(page-1)), page, hasNextPage), null),
-                processLore(options.getPreviousPageItem().getLore(), p, null, page, hasNextPage)
-            );
-            gui.setItem(options.getPreviousPageItem().getSlots(), previousPage);
+            // Adds Previous Page Item to Menu
+            DisplayItem previousPageDisplayItem = new DisplayItem(options.getPreviousPageItem());
+            ItemMeta previousPageItemMeta = previousPageDisplayItem.getItemStack().getItemMeta();
+            if (previousPageItemMeta != null) {
+                previousPageItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(previousPageDisplayItem.getName(), page, hasNextPage), null));
+                previousPageItemMeta.setLore(processLore(previousPageDisplayItem.getLore(), p, null, page, hasNextPage));
+                previousPageDisplayItem.getItemStack().setItemMeta(previousPageItemMeta);
+            }
+            gui.addDisplayItem(previousPageDisplayItem);
         }
 
         if (hasNextPage) {
-            ItemStack nextPage = TagGUI.createItem(
-                options.getNextPageItem().getMaterial(),
-                options.getNextPageItem().getData(),
-                1,
-                plugin.setPlaceholders(p, replacePageNumbers(options.getNextPageItem().getName().replace("%page%", String.valueOf(page+1)), page, true), null),
-                processLore(options.getNextPageItem().getLore(), p, null, page, true)
-            );
-            gui.setItem(options.getNextPageItem().getSlots(), nextPage);
+            // Adds Next Page Item to Menu
+            DisplayItem nextPageDisplayItem = new DisplayItem(options.getNextPageItem());
+            ItemMeta nextPageItemMeta = nextPageDisplayItem.getItemStack().getItemMeta();
+            if (nextPageItemMeta != null) {
+                nextPageItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(nextPageDisplayItem.getName(), page, hasNextPage), null));
+                nextPageItemMeta.setLore(processLore(nextPageDisplayItem.getLore(), p, null, page, hasNextPage));
+                nextPageDisplayItem.getItemStack().setItemMeta(nextPageItemMeta);
+            }
+            gui.addDisplayItem(nextPageDisplayItem);
         }
 
         gui.setPage(page);

--- a/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
+++ b/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
@@ -6,7 +6,6 @@ import me.clip.deluxetags.DeluxeTags;
 import me.clip.deluxetags.config.Lang;
 import me.clip.deluxetags.tags.DeluxeTag;
 import me.clip.deluxetags.utils.MsgUtils;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
+++ b/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
@@ -161,20 +161,22 @@ public class GUIHandler implements Listener {
             title = title.substring(0, 31);
         }
 
-        TagGUI gui = new TagGUI(title, page).setSlots(54);
+        int slots = options.getMenuSize();
+
+        TagGUI gui = new TagGUI(title, page).setSlots(slots);
 
         if (page > 1 && page <= pages) {
             ids = ids.subList((36 * page) - 36, ids.size());
         }
 
-        int count = 0;
+        int slot = 0;
         Map<Integer, String> tags = new HashMap<>();
         for (String id : ids) {
-            if (count >= 36) {
+            if (slot >= 36) {
                 break;
             }
 
-            tags.put(count, id);
+            tags.put(slot, id);
             DeluxeTag tag = plugin.getTagsHandler().getTagByIdentifier(id);
             if (tag == null) {
                 tag = plugin.getDummyTag();
@@ -182,7 +184,7 @@ public class GUIHandler implements Listener {
 
             if (tag.hasPermissionToUse(p)) {
                 gui.setItem(
-                    count,
+                    slot,
                     TagGUI.createItem(
                         options.getTagSelectItem().getMaterial(),
                         options.getTagSelectItem().getData(),
@@ -193,7 +195,7 @@ public class GUIHandler implements Listener {
                 );
             } else {
                 gui.setItem(
-                    count,
+                    slot,
                     TagGUI.createItem(
                         options.getTagVisibleItem().getMaterial(),
                         options.getTagVisibleItem().getData(),
@@ -203,7 +205,7 @@ public class GUIHandler implements Listener {
                     )
                 );
             }
-            count++;
+            slot++;
         }
         gui.setTags(tags);
 

--- a/src/main/java/me/clip/deluxetags/gui/GUIOptions.java
+++ b/src/main/java/me/clip/deluxetags/gui/GUIOptions.java
@@ -5,6 +5,7 @@ import me.clip.deluxetags.config.TagConfig;
 
 public class GUIOptions {
 	private final String menuName;
+	private int menuSize;
 	private DisplayItem tagSelectItem;
 	private DisplayItem tagVisibleItem;
 	private DisplayItem dividerItem;
@@ -16,7 +17,13 @@ public class GUIOptions {
 
 	public GUIOptions(DeluxeTags plugin) {
 		TagConfig config = plugin.getCfg();
-		menuName = config.loadMenuName();
+		menuName = config.getMenuName();
+
+		menuSize = config.getMenuSize();
+		// Validate menu size is 9, 18, 27, 36, 45 or 54
+		if (menuSize > 54 || menuSize < 9 || menuSize % 9 != 0) {
+			menuSize = 54;
+		}
 
 		for (ItemType type : ItemType.getCached()) {
 			switch (type) {
@@ -82,5 +89,9 @@ public class GUIOptions {
 
 	public String getMenuName() {
 		return menuName;
+	}
+
+	public int getMenuSize() {
+		return menuSize;
 	}
 }

--- a/src/main/java/me/clip/deluxetags/gui/GUIOptions.java
+++ b/src/main/java/me/clip/deluxetags/gui/GUIOptions.java
@@ -3,9 +3,12 @@ package me.clip.deluxetags.gui;
 import me.clip.deluxetags.DeluxeTags;
 import me.clip.deluxetags.config.TagConfig;
 
+import java.util.List;
+
 public class GUIOptions {
 	private final String menuName;
 	private int menuSize;
+	private List<Integer> tagSlots;
 	private DisplayItem tagSelectItem;
 	private DisplayItem tagVisibleItem;
 	private DisplayItem dividerItem;
@@ -24,6 +27,8 @@ public class GUIOptions {
 		if (menuSize > 54 || menuSize < 9 || menuSize % 9 != 0) {
 			menuSize = 54;
 		}
+
+		tagSlots = config.getTagSlots();
 
 		for (ItemType type : ItemType.getCached()) {
 			switch (type) {
@@ -93,5 +98,9 @@ public class GUIOptions {
 
 	public int getMenuSize() {
 		return menuSize;
+	}
+
+	public List<Integer> getTagSlots() {
+		return tagSlots;
 	}
 }

--- a/src/main/java/me/clip/deluxetags/gui/TagGUI.java
+++ b/src/main/java/me/clip/deluxetags/gui/TagGUI.java
@@ -75,7 +75,7 @@ public class TagGUI {
 		this.inventory = Bukkit.createInventory(null, slots, MsgUtils.color(displayName));
 		
 		for(Integer slot : this.items.keySet()){
-			if (slot >= slots) {
+			if (slot < 0 || slot >= slots) {
 				break;
 			}
 

--- a/src/main/java/me/clip/deluxetags/gui/TagGUI.java
+++ b/src/main/java/me/clip/deluxetags/gui/TagGUI.java
@@ -75,7 +75,7 @@ public class TagGUI {
 		this.inventory = Bukkit.createInventory(null, slots, MsgUtils.color(displayName));
 		
 		for(Integer slot : this.items.keySet()){
-			if (slot > slots) {
+			if (slot >= slots) {
 				break;
 			}
 

--- a/src/main/java/me/clip/deluxetags/gui/TagGUI.java
+++ b/src/main/java/me/clip/deluxetags/gui/TagGUI.java
@@ -53,16 +53,6 @@ public class TagGUI {
 		return this;
 	}
 
-	/**
-	 * @deprecated Use {@link TagGUI#addDisplayItem(DisplayItem)}
-	 */
-	@Deprecated
-	public TagGUI setItem(int slot, ItemStack item) {
-		List<Integer> singleSlot = Collections.singletonList(slot);
-		items.put(slot, new DisplayItem(ItemType.UNKNOWN, item, singleSlot));
-		return this;
-	}
-
 	public TagGUI setSlots(int slots){
 		this.slots = slots;
 		return this;

--- a/src/main/java/me/clip/deluxetags/gui/TagGUI.java
+++ b/src/main/java/me/clip/deluxetags/gui/TagGUI.java
@@ -20,9 +20,7 @@ public class TagGUI {
 	private final Map<Integer, ItemStack> items;
 	private final String displayName;
 	private int slots;
-
 	private int page;
-
 	
 	public TagGUI(String displayName, int page){
 		this.displayName = displayName;
@@ -76,7 +74,7 @@ public class TagGUI {
 		
 		for(Integer slot : this.items.keySet()){
 			if (slot < 0 || slot >= slots) {
-				break;
+				continue;
 			}
 
 			inventory.setItem(slot, this.items.get(slot));

--- a/src/main/java/me/clip/deluxetags/gui/TagGUI.java
+++ b/src/main/java/me/clip/deluxetags/gui/TagGUI.java
@@ -76,28 +76,6 @@ public class TagGUI {
 		
 		inGUI.put(player.getName(), this);
 	}
-
-	public static ItemStack createItem(Material mat, short data, int amount, String displayName, List<String> lore) {
-		if (mat == null) {
-			return null;
-		}
-		ItemStack item = new ItemStack(mat, amount);
-		if (data > 0) {
-			item.setDurability(data);
-		}
-		ItemMeta itemMeta = item.getItemMeta();
-		if (itemMeta == null) {
-			return null;
-		}
-		if (displayName != null) {
-			itemMeta.setDisplayName(displayName);
-		}
-		if (lore != null && !lore.isEmpty()) {
-			itemMeta.setLore(lore);
-		}
-		item.setItemMeta(itemMeta);
-		return item;
-	}
 	
 	public static boolean hasGUI(Player p) {
 		if (inGUI == null) {

--- a/src/main/java/me/clip/deluxetags/gui/TagGUI.java
+++ b/src/main/java/me/clip/deluxetags/gui/TagGUI.java
@@ -53,7 +53,6 @@ public class TagGUI {
 		return this;
 	}
 
-
 	/**
 	 * @deprecated Use {@link TagGUI#addDisplayItem(DisplayItem)}
 	 */

--- a/src/main/java/me/clip/deluxetags/gui/TagGUI.java
+++ b/src/main/java/me/clip/deluxetags/gui/TagGUI.java
@@ -1,8 +1,7 @@
 package me.clip.deluxetags.gui;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import me.clip.deluxetags.utils.MsgUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -17,7 +16,7 @@ public class TagGUI {
 	private Map<Integer, String> tags;
 
 	private Inventory inventory;
-	private final Map<Integer, ItemStack> items;
+	private final Map<Integer, DisplayItem> items;
 	private final String displayName;
 	private int slots;
 	private int page;
@@ -37,18 +36,18 @@ public class TagGUI {
 		return this.displayName;
 	}
  
-	public TagGUI clear(){
+	public TagGUI clear() {
 		this.items.clear();
 		this.tags = null;
 		return this;
 	}
 	
-	public boolean contains(ItemStack item){
+	public boolean contains(DisplayItem item) {
 		return this.items.containsValue(item);
 	}
 
-	public TagGUI setItem(List<Integer> slots, ItemStack item) {
-		for (Integer slot : slots) {
+	public TagGUI addDisplayItem(DisplayItem item) {
+		for (Integer slot : item.getSlots()) {
 			this.items.put(slot, item);
 		}
 		return this;
@@ -56,11 +55,12 @@ public class TagGUI {
 
 
 	/**
-	 * @deprecated Use {@link TagGUI#setItem(List, ItemStack)}
+	 * @deprecated Use {@link TagGUI#addDisplayItem(DisplayItem)}
 	 */
 	@Deprecated
-	public TagGUI setItem(int slot, ItemStack item){
-		items.put(slot, item);
+	public TagGUI setItem(int slot, ItemStack item) {
+		List<Integer> singleSlot = Collections.singletonList(slot);
+		items.put(slot, new DisplayItem(ItemType.UNKNOWN, item, singleSlot));
 		return this;
 	}
 
@@ -77,7 +77,7 @@ public class TagGUI {
 				continue;
 			}
 
-			inventory.setItem(slot, this.items.get(slot));
+			inventory.setItem(slot, this.items.get(slot).getItemStack());
 		}
 		player.openInventory(this.inventory);
 		
@@ -134,6 +134,12 @@ public class TagGUI {
 		getGUI(p).clear();
 		inGUI.remove(p.getName());
 		return true;
+	}
+
+	public ItemType getClickedItemType(int slot) {
+		DisplayItem clickedDisplayItem = this.items.get(slot);
+
+		return clickedDisplayItem != null ? clickedDisplayItem.getType() : null;
 	}
 
 	public int getPage() {

--- a/src/main/java/me/clip/deluxetags/gui/TagGUI.java
+++ b/src/main/java/me/clip/deluxetags/gui/TagGUI.java
@@ -48,7 +48,19 @@ public class TagGUI {
 	public boolean contains(ItemStack item){
 		return this.items.containsValue(item);
 	}
-	
+
+	public TagGUI setItem(List<Integer> slots, ItemStack item) {
+		for (Integer slot : slots) {
+			this.items.put(slot, item);
+		}
+		return this;
+	}
+
+
+	/**
+	 * @deprecated Use {@link TagGUI#setItem(List, ItemStack)}
+	 */
+	@Deprecated
 	public TagGUI setItem(int slot, ItemStack item){
 		items.put(slot, item);
 		return this;
@@ -63,6 +75,10 @@ public class TagGUI {
 		this.inventory = Bukkit.createInventory(null, slots, MsgUtils.color(displayName));
 		
 		for(Integer slot : this.items.keySet()){
+			if (slot > slots) {
+				break;
+			}
+
 			inventory.setItem(slot, this.items.get(slot));
 		}
 		player.openInventory(this.inventory);

--- a/src/main/java/me/clip/deluxetags/utils/ItemUtils.java
+++ b/src/main/java/me/clip/deluxetags/utils/ItemUtils.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class ItemUtils {
-  public static @NotNull ItemStack createItem(Material material, short data, String name, List<String> lore) {
+  public static @NotNull ItemStack createItem(@NotNull final Material material, short data, String name, List<String> lore) {
     if (material == null) {
       return null;
     }

--- a/src/main/java/me/clip/deluxetags/utils/ItemUtils.java
+++ b/src/main/java/me/clip/deluxetags/utils/ItemUtils.java
@@ -3,11 +3,12 @@ package me.clip.deluxetags.utils;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 public class ItemUtils {
-  public static ItemStack createItem(Material material, short data, String name, List<String> lore) {
+  public static @NotNull ItemStack createItem(Material material, short data, String name, List<String> lore) {
     if (material == null) {
       return null;
     }

--- a/src/main/java/me/clip/deluxetags/utils/ItemUtils.java
+++ b/src/main/java/me/clip/deluxetags/utils/ItemUtils.java
@@ -1,0 +1,35 @@
+package me.clip.deluxetags.utils;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+
+public class ItemUtils {
+  public static ItemStack createItem(Material material, short data, String name, List<String> lore) {
+    if (material == null) {
+      return null;
+    }
+
+    ItemStack item = new ItemStack(material, 1);
+    if (data > 0) {
+      item.setDurability(data);
+    }
+
+    ItemMeta itemMeta = item.getItemMeta();
+    if (itemMeta != null) {
+      if (name != null) {
+        itemMeta.setDisplayName(name);
+      }
+
+      if (lore != null && !lore.isEmpty()) {
+        itemMeta.setLore(lore);
+      }
+      item.setItemMeta(itemMeta);
+    }
+
+    return item;
+  }
+
+}


### PR DESCRIPTION
Tested against Paper 1.21.11, this PR adds configuration options for item slots, tag slots, GUI size and minor code clean-up/readability improvements.

Slots property supports same format as DeluxeMenus with `slots` and `slot` config properties where slot is used when slots isn't specified. Ranges are also supported too in the format `x-y` (e.g. 20-23 for 20, 21, 22, 23).

Closes https://github.com/HelpChat/DeluxeTags/issues/15

