### PR TITLE
Added support for Item Model, Model Data and Model Data Components on GUI Items

### DIFF
--- a/src/main/java/me/clip/deluxetags/config/TagConfig.java
+++ b/src/main/java/me/clip/deluxetags/config/TagConfig.java
@@ -10,10 +10,13 @@ import me.clip.deluxetags.gui.DisplayItem;
 import me.clip.deluxetags.gui.ItemType;
 import me.clip.deluxetags.tags.DeluxeTag;
 import me.clip.deluxetags.utils.ItemUtils;
+import me.clip.deluxetags.utils.VersionHelper;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 
 public class TagConfig {
@@ -231,6 +234,14 @@ public class TagConfig {
     slots = loadSlots(basePath + ".slots", basePath + ".slot");
 
     ItemStack itemStack = ItemUtils.createItem(material, data, displayName, lore);
+    if (VersionHelper.HAS_TOOLTIP_STYLE && config.isSet(basePath + ".item_model")) {
+      NamespacedKey itemModel = NamespacedKey.fromString(config.getString(basePath + ".item_model"));
+      if (itemModel != null) {
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        itemMeta.setItemModel(itemModel);
+        itemStack.setItemMeta(itemMeta);
+      }
+    }
 
     return material == null ? null : new DisplayItem(type, itemStack, slots);
   }

--- a/src/main/java/me/clip/deluxetags/config/TagConfig.java
+++ b/src/main/java/me/clip/deluxetags/config/TagConfig.java
@@ -4,13 +4,17 @@ import com.cryptomorin.xseries.XMaterial;
 
 import java.util.*;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 import me.clip.deluxetags.DeluxeTags;
 import me.clip.deluxetags.gui.DisplayItem;
 import me.clip.deluxetags.gui.ItemType;
+import me.clip.deluxetags.gui.options.CustomModelDataComponent;
 import me.clip.deluxetags.tags.DeluxeTag;
 import me.clip.deluxetags.utils.ItemUtils;
+import me.clip.deluxetags.utils.StringUtils;
 import me.clip.deluxetags.utils.VersionHelper;
+import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
@@ -18,6 +22,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class TagConfig {
 
@@ -234,14 +239,37 @@ public class TagConfig {
     slots = loadSlots(basePath + ".slots", basePath + ".slot");
 
     ItemStack itemStack = ItemUtils.createItem(material, data, displayName, lore);
+    ItemMeta itemMeta = itemStack.getItemMeta();
+
+    // Sets Item Model
     if (VersionHelper.HAS_TOOLTIP_STYLE && config.isSet(basePath + ".item_model")) {
       NamespacedKey itemModel = NamespacedKey.fromString(config.getString(basePath + ".item_model"));
       if (itemModel != null) {
-        ItemMeta itemMeta = itemStack.getItemMeta();
         itemMeta.setItemModel(itemModel);
-        itemStack.setItemMeta(itemMeta);
       }
     }
+
+    // Sets Model Data
+    if (VersionHelper.IS_CUSTOM_MODEL_DATA && config.isSet(basePath + ".model_data")) {
+      try {
+        final int modelData = config.getInt(basePath + ".model_data");
+        itemMeta.setCustomModelData(modelData);
+      } catch (final Exception ignored) {
+      }
+    }
+
+    // Sets Model Data Component
+    if (VersionHelper.IS_CUSTOM_MODEL_DATA_COMPONENT && config.isConfigurationSection(basePath + ".model_data_component")) {
+      CustomModelDataComponent configCustomModelDataComponent = CustomModelDataComponent.builder()
+        .colors(config.getStringList(basePath + ".model_data_component.colors"))
+        .flags(config.getStringList(basePath + ".model_data_component.flags"))
+        .floats(config.getStringList(basePath + ".model_data_component.floats"))
+        .strings(config.getStringList(basePath + ".model_data_component.strings"));
+
+      itemMeta.setCustomModelDataComponent(parseCustomModelDataComponent(configCustomModelDataComponent, itemMeta.getCustomModelDataComponent()));
+    }
+
+    itemStack.setItemMeta(itemMeta);
 
     return material == null ? null : new DisplayItem(type, itemStack, slots);
   }
@@ -327,5 +355,52 @@ public class TagConfig {
     }
 
     return slotsList;
+  }
+
+  private @NotNull org.bukkit.inventory.meta.components.CustomModelDataComponent parseCustomModelDataComponent(
+    @NotNull final CustomModelDataComponent unparsedComponent,
+    @NotNull final org.bukkit.inventory.meta.components.CustomModelDataComponent component
+  ) {
+    if (!unparsedComponent.colors().isEmpty()) {
+      final List<Color> colors = unparsedComponent.colors()
+        .stream()
+        .map(this::parseRGBColor)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+      component.setColors(colors);
+    }
+
+    if (!unparsedComponent.flags().isEmpty()) {
+      final List<Boolean> flags = unparsedComponent.flags()
+        .stream()
+        .map(Boolean::parseBoolean)
+        .collect(Collectors.toList());
+      component.setFlags(flags);
+    }
+
+    if (!unparsedComponent.floats().isEmpty()) {
+      final List<Float> floats = unparsedComponent.floats()
+        .stream()
+        .map(Float::parseFloat)
+        .collect(Collectors.toList());
+      component.setFloats(floats);
+    }
+
+    if (!unparsedComponent.strings().isEmpty()) {
+      final List<String> strings = unparsedComponent.strings()
+        .stream()
+        .collect(Collectors.toList());
+      component.setStrings(strings);
+    }
+
+    return component;
+  }
+
+  private @Nullable Color parseRGBColor(@NotNull final String input) {
+    final Color color = StringUtils.parseRGBColor(input);
+    if (color == null) {
+      plugin.getLogger().warning("Invalid RGB color found: " + input);
+    }
+    return color;
   }
 }

--- a/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
+++ b/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
@@ -247,7 +247,7 @@ public class GUIHandler implements Listener {
 
         // Adds Exit Item to Menu
         DisplayItem exitDisplayItem = new DisplayItem(options.getExitItem());
-        ItemMeta exitItemMeta = dividerDisplayItem.getItemStack().getItemMeta();
+        ItemMeta exitItemMeta = exitDisplayItem.getItemStack().getItemMeta();
         if (exitItemMeta != null) {
             exitItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(exitDisplayItem.getName(), page, hasNextPage), null));
             exitItemMeta.setLore(processLore(exitDisplayItem.getLore(), p, null, page, hasNextPage));

--- a/src/main/java/me/clip/deluxetags/gui/options/CustomModelDataComponent.java
+++ b/src/main/java/me/clip/deluxetags/gui/options/CustomModelDataComponent.java
@@ -1,0 +1,65 @@
+package me.clip.deluxetags.gui.options;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CustomModelDataComponent {
+  private List<String> colors = new ArrayList<>();
+  private List<String> flags = new ArrayList<>();
+  private List<String> floats = new ArrayList<>();
+  private List<String> strings = new ArrayList<>();
+
+  private CustomModelDataComponent() {
+    // Private constructor to force builder usage
+  }
+
+  @NotNull
+  public CustomModelDataComponent colors(@NotNull final List<@NotNull String> colors) {
+    this.colors = colors;
+    return this;
+  }
+
+  @NotNull
+  public List<@NotNull String> colors() {
+    return colors;
+  }
+
+  @NotNull
+  public CustomModelDataComponent flags(@NotNull final List<@NotNull String> flags) {
+    this.flags = flags;
+    return this;
+  }
+
+  @NotNull
+  public List<@NotNull String> flags() {
+    return flags;
+  }
+
+  @NotNull
+  public CustomModelDataComponent floats(@NotNull final List<@NotNull String> floats) {
+    this.floats = floats;
+    return this;
+  }
+
+  @NotNull
+  public List<@NotNull String> floats() {
+    return floats;
+  }
+
+  @NotNull
+  public CustomModelDataComponent strings(@NotNull final List<@NotNull String> strings) {
+    this.strings = strings;
+    return this;
+  }
+
+  @NotNull
+  public List<@NotNull String> strings() {
+    return strings;
+  }
+
+  public static @NotNull CustomModelDataComponent builder() {
+    return new CustomModelDataComponent();
+  }
+}

--- a/src/main/java/me/clip/deluxetags/utils/StringUtils.java
+++ b/src/main/java/me/clip/deluxetags/utils/StringUtils.java
@@ -1,0 +1,21 @@
+package me.clip.deluxetags.utils;
+
+import org.bukkit.Color;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class StringUtils {
+  @Nullable
+  public static Color parseRGBColor(@NotNull final String input) {
+    final String[] parts = input.split(",");
+    try {
+      return Color.fromRGB(
+        Integer.parseInt(parts[0].trim()),
+        Integer.parseInt(parts[1].trim()),
+        Integer.parseInt(parts[2].trim())
+      );
+    } catch (final Exception exception) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/me/clip/deluxetags/utils/VersionHelper.java
+++ b/src/main/java/me/clip/deluxetags/utils/VersionHelper.java
@@ -1,0 +1,224 @@
+package me.clip.deluxetags.utils;
+
+import com.google.common.primitives.Ints;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.event.inventory.InventoryType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Class for detecting server version.
+ *
+ * @author Matt from triumph-gui
+ */
+public class VersionHelper {
+
+  private static final String PACKAGE_NAME = Bukkit.getServer().getClass().getPackage().getName();
+  public static final String NMS_VERSION = PACKAGE_NAME.substring(PACKAGE_NAME.lastIndexOf('.') + 1);
+
+  // Custom Model Data Component
+  private static final int V1_21_4 = 1_21_4;
+  // Tooltip Style & Item Model
+  private static final int V1_21_2 = 1_21_2;
+  // Data components
+  private static final int V1_20_5 = 1_20_5;
+  // ArmorTrims
+  private static final int V1_19_4 = 1194;
+  // PlayerProfile API
+  private static final int V1_18_1 = 1181;
+  // Mojang obfuscation changes
+  private static final int V1_17 = 1170;
+  // Material and components on items change
+  private static final int V1_13 = 1130;
+  // PDC and customModelData
+  private static final int V1_14 = 1140;
+  // Hex colors
+  private static final int V1_16 = 1160;
+  // Paper adventure changes
+  private static final int V1_16_5 = 1165;
+  // SkullMeta#setOwningPlayer was added
+  private static final int V1_12 = 1120;
+
+  public static final int CURRENT_VERSION = getCurrentVersion();
+
+  private static final boolean IS_PAPER = checkPaper();
+
+  /**
+   * Checks if the current version includes the setTooltipStyle and setItemModel
+   */
+  public static final boolean HAS_TOOLTIP_STYLE = CURRENT_VERSION >= V1_21_2;
+
+  /**
+   * Checks if the current version includes the <a href="https://minecraft.wiki/w/Data_component_format">Data Components</a>
+   */
+  public static final boolean HAS_DATA_COMPONENTS = CURRENT_VERSION >= V1_20_5;
+
+  /**
+   * Checks if the current version includes the ArmorTrims API
+   */
+  public static final boolean HAS_ARMOR_TRIMS = CURRENT_VERSION >= V1_19_4;
+  /**
+   * Checks if current version includes the PlayerProfile API
+   */
+  public static final boolean HAS_PLAYER_PROFILES = CURRENT_VERSION >= V1_18_1;
+
+  /**
+   * Checks if the current version was a version without versioned packages.
+   */
+  public static final boolean HAS_OBFUSCATED_NAMES = CURRENT_VERSION >= V1_17;
+
+  /**
+   * Checks if the version supports Components or not
+   * Paper versions above 1.16.5 would be true
+   * Spigot always false
+   */
+  public static final boolean IS_COMPONENT = IS_PAPER && CURRENT_VERSION >= V1_16_5;
+
+  /**
+   * Checks if the version is lower than 1.13 due to the item changes
+   */
+  public static final boolean IS_ITEM_LEGACY = CURRENT_VERSION < V1_13;
+
+  /**
+   * Checks if the version supports {@link org.bukkit.persistence.PersistentDataContainer}
+   */
+  public static final boolean IS_PDC_VERSION = CURRENT_VERSION >= V1_14;
+
+  /**
+   * Checks if the version doesn't have {@link org.bukkit.inventory.meta.SkullMeta#setOwningPlayer(OfflinePlayer)} and
+   * {@link org.bukkit.inventory.meta.SkullMeta#setOwner(String)} should be used instead
+   */
+  public static final boolean IS_SKULL_OWNER_LEGACY = CURRENT_VERSION <= V1_12;
+
+  /**
+   * Checks if the version has {@link org.bukkit.inventory.meta.ItemMeta#setCustomModelData(Integer)}
+   */
+  public static final boolean IS_CUSTOM_MODEL_DATA = CURRENT_VERSION >= V1_14;
+
+  public static final boolean IS_CUSTOM_MODEL_DATA_COMPONENT = CURRENT_VERSION >= V1_21_4;
+
+  public static final boolean IS_HEX_VERSION = CURRENT_VERSION >= V1_16;
+
+  private static List<InventoryType> CHEST_INVENTORY_TYPES = null;
+
+  private static List<InventoryType> VALID_INVENTORY_TYPES = null;
+
+  private static List<InventoryType> getChestInventoryTypes() {
+    if (CHEST_INVENTORY_TYPES != null) return CHEST_INVENTORY_TYPES;
+
+    if (CURRENT_VERSION >= V1_14) {
+      CHEST_INVENTORY_TYPES = Arrays.asList(
+        InventoryType.BARREL,
+        InventoryType.CHEST,
+        InventoryType.CRAFTING,
+        InventoryType.CREATIVE,
+        InventoryType.ENDER_CHEST,
+        InventoryType.LECTERN,
+        InventoryType.MERCHANT,
+        InventoryType.SHULKER_BOX
+      );
+
+      return CHEST_INVENTORY_TYPES;
+    }
+
+    CHEST_INVENTORY_TYPES = Arrays.asList(
+      InventoryType.CHEST,
+      InventoryType.CRAFTING,
+      InventoryType.CREATIVE,
+      InventoryType.ENDER_CHEST,
+      InventoryType.MERCHANT,
+      InventoryType.SHULKER_BOX
+    );
+
+    return CHEST_INVENTORY_TYPES;
+  }
+
+  public static List<InventoryType> getValidInventoryTypes() {
+    if (VALID_INVENTORY_TYPES != null) return VALID_INVENTORY_TYPES;
+
+    final List<InventoryType> chestInventoryTypes = getChestInventoryTypes();
+    final List<InventoryType> validInventoryTypes = new ArrayList<>();
+
+    for (final InventoryType inventoryType : InventoryType.values()) {
+      if (inventoryType != InventoryType.CHEST && chestInventoryTypes.contains(inventoryType)) continue;
+      validInventoryTypes.add(inventoryType);
+    }
+
+    VALID_INVENTORY_TYPES = validInventoryTypes;
+    return VALID_INVENTORY_TYPES;
+  }
+
+  /**
+   * Check if the server has access to the Paper API
+   * Taken from <a href="https://github.com/PaperMC/PaperLib">PaperLib</a>
+   *
+   * @return True if on Paper server (or forks), false anything else
+   */
+  private static boolean checkPaper() {
+    try {
+      Class.forName("com.destroystokyo.paper.PaperConfig");
+      return true;
+    } catch (ClassNotFoundException ignored) {
+      return false;
+    }
+  }
+
+  /**
+   * Gets the current server version
+   *
+   * @return A protocol like number representing the version, for example 1.16.5 - 1165
+   */
+  private static int getCurrentVersion() {
+    // No need to cache since will only run once
+    final Matcher matcher = Pattern.compile("(?<version>\\d+\\.\\d+)(?<patch>\\.\\d+)?").matcher(Bukkit.getBukkitVersion());
+
+    final StringBuilder stringBuilder = new StringBuilder();
+    if (matcher.find()) {
+      stringBuilder.append(matcher.group("version").replace(".", ""));
+      final String patch = matcher.group("patch");
+      if (patch == null) stringBuilder.append("0");
+      else stringBuilder.append(patch.replace(".", ""));
+    }
+
+    //noinspection UnstableApiUsage
+    final Integer version = Ints.tryParse(stringBuilder.toString());
+
+    // Should never fail
+    if (version == null) throw new RuntimeException("Could not retrieve server version!");
+
+    return version;
+  }
+
+  public static String getNmsVersion() {
+    final String version = Bukkit.getServer().getClass().getPackage().getName();
+    return version.substring(version.lastIndexOf('.') + 1);
+  }
+
+  /**
+   * Gets the NMS class from class name.
+   *
+   * @return The NMS class.
+   */
+  public static Class<?> getNMSClass(final String pkg, final String className) throws ClassNotFoundException {
+    if (VersionHelper.HAS_OBFUSCATED_NAMES) {
+      return Class.forName("net.minecraft." + pkg + "."  + className);
+    }
+    return Class.forName("net.minecraft.server." + VersionHelper.NMS_VERSION + "." + className);
+  }
+
+  /**
+   * Gets the craft class from class name.
+   *
+   * @return The craft class.
+   */
+  public static Class<?> getCraftClass(@NotNull final String name) throws ClassNotFoundException {
+    return Class.forName("org.bukkit.craftbukkit." + NMS_VERSION + "." + name);
+  }
+
+}


### PR DESCRIPTION
Tested on Spigot 26.1.2.

This PR adds support for Item Model, Model Data and Model Data Components on GUI Items in the same format of DeluxeMenus.
<img width="449" height="457" alt="image" src="https://github.com/user-attachments/assets/8d3f5c4f-0dde-401d-a362-08f321a2d4da" />

This PR also fixes the Exit Item incorrectly referencing the Divider Item Meta and uses the same VersionHelper, StringUtils and CustomModelDataComponent classes from DeluxeMenus.

Closes #27 