### PR TITLE
feat: categories

### DIFF
--- a/src/main/java/me/clip/deluxetags/DeluxeTags.java
+++ b/src/main/java/me/clip/deluxetags/DeluxeTags.java
@@ -56,6 +56,7 @@ public class DeluxeTags extends JavaPlugin {
 
 		reloadFormattingOptions();
 
+		cfg.loadCategories();
 		int loaded = cfg.loadTags();
 		if (loaded == 1) {
 			getLogger().info("1 tag loaded");

--- a/src/main/java/me/clip/deluxetags/commands/TagCommand.java
+++ b/src/main/java/me/clip/deluxetags/commands/TagCommand.java
@@ -658,6 +658,7 @@ public class TagCommand implements CommandExecutor {
       plugin.getCfg().reload();
 
       plugin.getTagsHandler().unloadData();
+      plugin.getCfg().loadCategories();
       int loaded = plugin.getCfg().loadTags();
 
       plugin.reloadFormattingOptions();

--- a/src/main/java/me/clip/deluxetags/config/TagConfig.java
+++ b/src/main/java/me/clip/deluxetags/config/TagConfig.java
@@ -11,6 +11,7 @@ import me.clip.deluxetags.gui.DisplayItem;
 import me.clip.deluxetags.gui.ItemType;
 import me.clip.deluxetags.gui.options.CustomModelDataComponent;
 import me.clip.deluxetags.tags.DeluxeTag;
+import me.clip.deluxetags.tags.DeluxeTagCategory;
 import me.clip.deluxetags.utils.ItemUtils;
 import me.clip.deluxetags.utils.StringUtils;
 import me.clip.deluxetags.utils.VersionHelper;
@@ -55,22 +56,29 @@ public class TagConfig {
             + "\ndeluxetags:"
             + "\n  VIP: "
             + "\n    order: 1"
+            + "\n    category: general"
             + "\n    tag: '&7[&eVIP&7]'"
             + "\n    description: 'This tag is awarded by getting VIP'"
             + "\n"
-            + "\nPlaceholders for your chat plugin that supports PlaceholderAPI (Including DeluxeChat)"
+            + "\nCreate your categories using the following format:"
+            + "\n"
+            + "\ncategories:"
+            + "\n  general:"
+            + "\n    order: 1"
+            + "\n    item: NAME_TAG"
+            + "\n    name: '&6General'"
+            + "\n    lore:"
+            + "\n      - '&7Click to view general tags'"
+            + "\n    gui_name: '&6General tags'"
+            + "\n"
+            + "\nThe reserved 'all' category configures the automatic all-tags selector item."
+            + "\n"
+            + "\nPlaceholders for your chat plugin that supports PlaceholderAPI"
             + "\n"
             + "\n%deluxetags_identifier% - display the players active tag identifier"
             + "\n%deluxetags_tag% - display the players active tag"
             + "\n%deluxetags_description% - display the players active tag description"
-            + "\n%deluxetags_amount% - display the amount of tags a player has access to"
-            + "\n"
-            + "\nPlaceholders for your essentials/chat handling formats config:"
-            + "\n"
-            + "\n{deluxetags_identifier} - display the players active tag identifier"
-            + "\n{deluxetags_tag} - display the players active tag"
-            + "\n{deluxetags_description} - display the players active tag description"
-            + "\n{deluxetags_amount} - display the amount of tags a player has access to");
+            + "\n%deluxetags_amount% - display the amount of tags a player has access to");
 
     config.addDefault("force_tags", false);
     config.addDefault("check_updates", true);
@@ -135,6 +143,14 @@ public class TagConfig {
         Collections.singletonList("&7Exit the tags menu"));
     addDefaultUnlessAlternativePathExists("gui.exit_item.slots", Arrays.asList(48, 50), "gui.exit_item.slot");
 
+    // Category Back item
+    config.addDefault("gui.category_back_item.material", "ARROW");
+    config.addDefault("gui.category_back_item.data", 0);
+    config.addDefault("gui.category_back_item.displayname", "&6Back to categories");
+    config.addDefault("gui.category_back_item.lore",
+        Collections.singletonList("&7Return to category selection"));
+    addDefaultUnlessAlternativePathExists("gui.category_back_item.slot", 47, "gui.category_back_item.slots");
+
     // Next Page item
     config.addDefault("gui.next_page.material", "PAPER");
     config.addDefault("gui.next_page.data", 0);
@@ -151,12 +167,30 @@ public class TagConfig {
         Collections.singletonList("&7Move to the previous page"));
     addDefaultUnlessAlternativePathExists("gui.previous_page.slot", 45, "gui.previous_page.slots");
 
+    // Category properties
+    config.addDefault("categories.all.order", 0);
+    config.addDefault("categories.all.item", "BOOK");
+    config.addDefault("categories.all.name", "&6All Tags");
+    config.addDefault("categories.all.lore",
+        Collections.singletonList("&7Click to view all available tags"));
+    config.addDefault("categories.all.gui_name", "&6All Tags");
+
+    config.addDefault("categories.general.order", 1);
+    config.addDefault("categories.general.item", "NAME_TAG");
+    config.addDefault("categories.general.name", "&6General");
+    config.addDefault("categories.general.lore",
+        Collections.singletonList("&7Click to view general tags"));
+    config.addDefault("categories.general.gui_name", "&6General tags");
+
     if (!config.contains("deluxetags")) {
       config.set("deluxetags.example.order", 1);
+      config.set("deluxetags.example.category", DeluxeTagCategory.GENERAL_IDENTIFIER);
       config.set("deluxetags.example.tag", "&8[&bDeluxeTags&8]");
       config.set("deluxetags.example.description", "&cAwarded for using DeluxeTags!");
       config.set("deluxetags.example.permission", "deluxetags.tag.example");
     }
+
+    migrateTagCategories();
 
     config.options().copyDefaults(true);
     plugin.saveConfig();
@@ -173,6 +207,21 @@ public class TagConfig {
   private void addDefaultUnlessAlternativePathExists(String path, Object value, String alternativePath) {
     if (!config.contains(alternativePath)) {
       config.addDefault(path, value);
+    }
+  }
+
+  private void migrateTagCategories() {
+    ConfigurationSection deluxetags = config.getConfigurationSection("deluxetags");
+    if (deluxetags == null) {
+      return;
+    }
+
+    for (String identifier : deluxetags.getKeys(false)) {
+      String categoryPath = "deluxetags." + identifier + ".category";
+      String category = config.getString(categoryPath);
+      if (category == null || category.trim().isEmpty() || category.equalsIgnoreCase(DeluxeTagCategory.ALL_IDENTIFIER)) {
+        config.set(categoryPath, DeluxeTagCategory.GENERAL_IDENTIFIER);
+      }
     }
   }
 
@@ -284,6 +333,68 @@ public class TagConfig {
     return material == null ? null : new DisplayItem(type, itemStack, slots);
   }
 
+  public int loadCategories() {
+    int loaded = 0;
+    boolean loadedAllCategory = false;
+    boolean loadedRealCategory = false;
+
+    ConfigurationSection categories = config.getConfigurationSection("categories");
+    Set<String> keys = categories != null ? categories.getKeys(false) : Collections.emptySet();
+
+    for (String identifier : keys) {
+      if (identifier.trim().isEmpty()) {
+        continue;
+      }
+
+      String basePath = "categories." + identifier;
+      boolean allCategory = identifier.equalsIgnoreCase(DeluxeTagCategory.ALL_IDENTIFIER);
+
+      Material fallback = allCategory ? XMaterial.BOOK.parseMaterial() : XMaterial.NAME_TAG.parseMaterial();
+      Material material = loadCategoryMaterial(config.getString(basePath + ".item"), fallback);
+      String defaultName = allCategory ? "&6All Tags" : "&6" + identifier;
+      String name = config.getString(basePath + ".name", defaultName);
+      List<String> lore = config.getStringList(basePath + ".lore");
+      String guiName = config.getString(basePath + ".gui_name", name);
+      int order = config.getInt(basePath + ".order", allCategory ? 0 : loaded + 1);
+
+      plugin.getTagsHandler().loadCategory(new DeluxeTagCategory(identifier, order, material, name, lore, guiName, allCategory));
+      if (allCategory) {
+        loadedAllCategory = true;
+      } else {
+        loadedRealCategory = true;
+      }
+      loaded++;
+    }
+
+    if (!loadedAllCategory) {
+      plugin.getTagsHandler().loadCategory(new DeluxeTagCategory(
+          DeluxeTagCategory.ALL_IDENTIFIER,
+          0,
+          XMaterial.BOOK.parseMaterial(),
+          "&6All Tags",
+          Collections.singletonList("&7Click to view all available tags"),
+          "&6All Tags",
+          true
+      ));
+      loaded++;
+    }
+
+    if (!loadedRealCategory) {
+      plugin.getTagsHandler().loadCategory(new DeluxeTagCategory(
+          DeluxeTagCategory.GENERAL_IDENTIFIER,
+          1,
+          XMaterial.NAME_TAG.parseMaterial(),
+          "&6General",
+          Collections.singletonList("&7Click to view general tags"),
+          "&6General tags",
+          false
+      ));
+      loaded++;
+    }
+
+    return loaded;
+  }
+
   public int loadTags() {
     int loaded = 0;
 
@@ -317,7 +428,13 @@ public class TagConfig {
       }
       int priority = config.getInt("deluxetags." + identifier + ".order");
 
-      DeluxeTag t = new DeluxeTag(priority, identifier, tag, description);
+      String category = normalizeTagCategory(config.getString("deluxetags." + identifier + ".category", DeluxeTagCategory.GENERAL_IDENTIFIER));
+      if (!category.equalsIgnoreCase(DeluxeTagCategory.GENERAL_IDENTIFIER) && !plugin.getTagsHandler().hasCategory(category)) {
+        plugin.getLogger().log(Level.INFO, "Could not find category: " + category + " for tag: " + identifier + ". Using general instead.");
+        category = DeluxeTagCategory.GENERAL_IDENTIFIER;
+      }
+
+      DeluxeTag t = new DeluxeTag(priority, identifier, tag, description, category);
       t.setPermission(config.getString("deluxetags." + identifier + ".permission", "deluxetags.tag." + identifier));
       plugin.getTagsHandler().loadTag(t);
       loaded++;
@@ -327,11 +444,16 @@ public class TagConfig {
   }
 
   public void saveTag(DeluxeTag tag) {
-    saveTag(tag.getPriority(), tag.getIdentifier(), tag.getDisplayTag(), tag.getDescription(), tag.getPermission());
+    saveTag(tag.getPriority(), tag.getIdentifier(), tag.getDisplayTag(), tag.getDescription(), tag.getPermission(), tag.getCategory());
   }
 
   public void saveTag(int priority, String identifier, String tag, String description, String permission) {
+    saveTag(priority, identifier, tag, description, permission, getSavedCategory(identifier));
+  }
+
+  public void saveTag(int priority, String identifier, String tag, String description, String permission, String category) {
     config.set("deluxetags." + identifier + ".order", priority);
+    config.set("deluxetags." + identifier + ".category", normalizeTagCategory(category));
     config.set("deluxetags." + identifier + ".tag", tag);
     if (description == null) {
       description = "&fDescription for tag " + identifier;
@@ -344,6 +466,35 @@ public class TagConfig {
   public void removeTag(String identifier) {
     config.set("deluxetags." + identifier, null);
     plugin.saveConfig();
+  }
+
+  private Material loadCategoryMaterial(String materialName, Material fallback) {
+    if (fallback == null) {
+      fallback = Material.NAME_TAG;
+    }
+
+    if (materialName == null || materialName.trim().isEmpty()) {
+      return fallback;
+    }
+
+    try {
+      Material material = XMaterial.matchXMaterial(materialName.toUpperCase(Locale.ROOT)).get().parseMaterial();
+      return material == null ? fallback : material;
+    } catch (Exception e) {
+      return fallback;
+    }
+  }
+
+  private String normalizeTagCategory(String category) {
+    if (category == null || category.trim().isEmpty() || category.equalsIgnoreCase(DeluxeTagCategory.ALL_IDENTIFIER)) {
+      return DeluxeTagCategory.GENERAL_IDENTIFIER;
+    }
+
+    return category;
+  }
+
+  private String getSavedCategory(String identifier) {
+    return normalizeTagCategory(config.getString("deluxetags." + identifier + ".category", DeluxeTagCategory.GENERAL_IDENTIFIER));
   }
 
   private List<Integer> loadSlots(String slotsPath, String slotPath) {

--- a/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
+++ b/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
@@ -5,6 +5,8 @@ import java.util.*;
 import me.clip.deluxetags.DeluxeTags;
 import me.clip.deluxetags.config.Lang;
 import me.clip.deluxetags.tags.DeluxeTag;
+import me.clip.deluxetags.tags.DeluxeTagCategory;
+import me.clip.deluxetags.utils.ItemUtils;
 import me.clip.deluxetags.utils.MsgUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -64,9 +66,16 @@ public class GUIHandler implements Listener {
                 p.closeInventory();
                 break;
             case NEXT_PAGE:
-                openMenu(p, gui.getPage()+1);
+                if (gui.isCategoryMenu()) {
+                    openCategoryMenu(p, gui.getPage()+1);
+                } else {
+                    openTagMenu(p, gui.getCategoryIdentifier(), gui.getPage()+1);
+                }
                 break;
             case DIVIDER_ITEM:
+                break;
+            case CATEGORY_BACK_ITEM:
+                openCategoryMenu(p, 1);
                 break;
             case HAS_TAG_ITEM:
                 final DeluxeTag currentTag = plugin.getTagsHandler().getPlayerActiveTag(p);
@@ -85,9 +94,40 @@ public class GUIHandler implements Listener {
                 p.updateInventory();
                 break;
             case PREVIOUS_PAGE:
-                openMenu(p, gui.getPage()-1);
+                if (gui.isCategoryMenu()) {
+                    openCategoryMenu(p, gui.getPage()-1);
+                } else {
+                    openTagMenu(p, gui.getCategoryIdentifier(), gui.getPage()-1);
+                }
                 break;
             case TAG_SELECT_ITEM:
+                if (gui.isCategoryMenu()) {
+                    Map<Integer, String> categories;
+                    try {
+                        categories = gui.getCategories();
+                    } catch (NullPointerException ex) {
+                        TagGUI.close(p);
+                        p.closeInventory();
+                        return;
+                    }
+
+                    if (categories.isEmpty()) {
+                        TagGUI.close(p);
+                        p.closeInventory();
+                        return;
+                    }
+
+                    String categoryId = categories.get(slot);
+                    if (categoryId == null || categoryId.isEmpty()) {
+                        TagGUI.close(p);
+                        p.closeInventory();
+                        return;
+                    }
+
+                    openTagMenu(p, categoryId, 1);
+                    break;
+                }
+
                 Map<Integer, String> tags;
                 try {
                     tags = gui.getTags();
@@ -159,7 +199,85 @@ public class GUIHandler implements Listener {
     }
 
     public boolean openMenu(Player p, int page) {
-        List<String> ids = plugin.getTagsHandler().getPlayerVisibleTagIdentifiers(p);
+        List<DeluxeTagCategory> visibleCategories = plugin.getTagsHandler().getPlayerVisibleCategories(p);
+        if (visibleCategories.isEmpty()) {
+            return false;
+        }
+
+        if (visibleCategories.size() == 1) {
+            return openTagMenu(p, visibleCategories.get(0).getIdentifier(), page);
+        }
+
+        return openCategoryMenu(p, page);
+    }
+
+    private boolean openCategoryMenu(Player p, int page) {
+        List<DeluxeTagCategory> categories = plugin.getTagsHandler().getPlayerSelectableCategories(p);
+        if (categories.isEmpty()) {
+            return false;
+        }
+
+        GUIOptions options = plugin.getGuiOptions();
+
+        List<Integer> tagSlots = options.getTagSlots();
+        if (tagSlots.isEmpty()) {
+            return false;
+        }
+
+        int pages = (int) Math.ceil(categories.size() / (double) tagSlots.size());
+        page = clampPage(page, pages);
+        boolean hasNextPage = page < pages;
+
+        String title = prepareTitle(p, options.getMenuName(), page, hasNextPage);
+        int menuSlots = options.getMenuSize();
+
+        TagGUI gui = new TagGUI(title, page).setSlots(menuSlots);
+        gui.setCategoryMenu(true);
+
+        List<DeluxeTagCategory> pageCategories = getPageItems(categories, page, tagSlots.size());
+        int categoryIndex = 0;
+        Map<Integer, String> categorySlots = new HashMap<>();
+        for (int tagSlot : tagSlots) {
+            if (categoryIndex >= pageCategories.size()) {
+                break;
+            }
+
+            DeluxeTagCategory category = pageCategories.get(categoryIndex);
+            categorySlots.put(tagSlot, category.getIdentifier());
+
+            DisplayItem categoryDisplayItem = new DisplayItem(
+                ItemType.TAG_SELECT_ITEM,
+                ItemUtils.createItem(category.getMaterial(), (short) 0, category.getName(), category.getLore()),
+                Collections.singletonList(tagSlot)
+            );
+            ItemMeta categoryItemMeta = categoryDisplayItem.getItemStack().getItemMeta();
+            if (categoryItemMeta != null) {
+                categoryItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(categoryDisplayItem.getName(), page, hasNextPage), null));
+                categoryItemMeta.setLore(processLore(categoryDisplayItem.getLore(), p, null, page, hasNextPage));
+                categoryDisplayItem.getItemStack().setItemMeta(categoryItemMeta);
+            }
+            gui.addDisplayItem(categoryDisplayItem);
+
+            categoryIndex++;
+        }
+        gui.setCategories(categorySlots);
+
+        addStaticMenuItems(gui, p, page, hasNextPage);
+        gui.setPage(page);
+        gui.openInventory(p);
+        return true;
+    }
+
+    private boolean openTagMenu(Player p, String categoryIdentifier, int page) {
+        if (categoryIdentifier == null || categoryIdentifier.isEmpty()) {
+            categoryIdentifier = DeluxeTagCategory.ALL_IDENTIFIER;
+        }
+
+        if (!canOpenCategory(p, categoryIdentifier)) {
+            return false;
+        }
+
+        List<String> ids = plugin.getTagsHandler().getPlayerVisibleTagIdentifiers(p, categoryIdentifier);
         if (ids.isEmpty()) {
             return false;
         }
@@ -167,23 +285,23 @@ public class GUIHandler implements Listener {
         GUIOptions options = plugin.getGuiOptions();
 
         List<Integer> tagSlots = options.getTagSlots();
+        if (tagSlots.isEmpty()) {
+            return false;
+        }
 
         int pages = (int) Math.ceil(ids.size() / (double) tagSlots.size());
+        page = clampPage(page, pages);
         boolean hasNextPage = page < pages;
 
-        String title = options.getMenuName();
-        title = replacePageNumbers(plugin.setPlaceholders(p, title, null), page, hasNextPage);
-        if (title.length() > 32) {
-            title = title.substring(0, 31);
-        }
+        DeluxeTagCategory category = plugin.getTagsHandler().getCategoryByIdentifier(categoryIdentifier);
+        String title = prepareTitle(p, category != null ? category.getGuiName() : options.getMenuName(), page, hasNextPage);
 
         int menuSlots = options.getMenuSize();
 
         TagGUI gui = new TagGUI(title, page).setSlots(menuSlots);
+        gui.setCategoryIdentifier(categoryIdentifier);
 
-        if (page > 1 && page <= pages) {
-            ids = ids.subList((tagSlots.size() * page) - tagSlots.size(), ids.size());
-        }
+        ids = getPageItems(ids, page, tagSlots.size());
 
         int idIndex = 0;
         Map<Integer, String> tags = new HashMap<>();
@@ -214,6 +332,15 @@ public class GUIHandler implements Listener {
             idIndex++;
         }
         gui.setTags(tags);
+
+        addStaticMenuItems(gui, p, page, hasNextPage);
+        gui.setPage(page);
+        gui.openInventory(p);
+        return true;
+    }
+
+    private void addStaticMenuItems(TagGUI gui, Player p, int page, boolean hasNextPage) {
+        GUIOptions options = plugin.getGuiOptions();
 
         // Adds Divider Item to Menu
         DisplayItem dividerDisplayItem = new DisplayItem(options.getDividerItem());
@@ -255,6 +382,18 @@ public class GUIHandler implements Listener {
         }
         gui.addDisplayItem(exitDisplayItem);
 
+        boolean showCategoryBack = !gui.isCategoryMenu() && shouldShowCategorySelector(p);
+        if (showCategoryBack) {
+            DisplayItem categoryBackDisplayItem = new DisplayItem(options.getCategoryBackItem());
+            ItemMeta categoryBackItemMeta = categoryBackDisplayItem.getItemStack().getItemMeta();
+            if (categoryBackItemMeta != null) {
+                categoryBackItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(categoryBackDisplayItem.getName(), page, hasNextPage), null));
+                categoryBackItemMeta.setLore(processLore(categoryBackDisplayItem.getLore(), p, null, page, hasNextPage));
+                categoryBackDisplayItem.getItemStack().setItemMeta(categoryBackItemMeta);
+            }
+            gui.addDisplayItem(categoryBackDisplayItem);
+        }
+
         if (page > 1) {
             // Adds Previous Page Item to Menu
             DisplayItem previousPageDisplayItem = new DisplayItem(options.getPreviousPageItem());
@@ -279,9 +418,59 @@ public class GUIHandler implements Listener {
             gui.addDisplayItem(nextPageDisplayItem);
         }
 
-        gui.setPage(page);
-        gui.openInventory(p);
-        return true;
+    }
+
+    private boolean canOpenCategory(Player player, String categoryIdentifier) {
+        if (categoryIdentifier.equalsIgnoreCase(DeluxeTagCategory.ALL_IDENTIFIER)) {
+            return plugin.getTagsHandler().getPlayerVisibleCategories(player).size() >= 2;
+        }
+
+        for (DeluxeTagCategory category : plugin.getTagsHandler().getPlayerVisibleCategories(player)) {
+            if (category.getIdentifier().equalsIgnoreCase(categoryIdentifier)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean shouldShowCategorySelector(Player player) {
+        return plugin.getTagsHandler().getPlayerVisibleCategories(player).size() >= 2;
+    }
+
+    private int clampPage(int page, int pages) {
+        if (pages <= 0) {
+            return 1;
+        }
+
+        if (page < 1) {
+            return 1;
+        }
+
+        return Math.min(page, pages);
+    }
+
+    private String prepareTitle(Player player, String title, int page, boolean hasNextPage) {
+        if (title == null) {
+            title = "";
+        }
+
+        title = replacePageNumbers(plugin.setPlaceholders(player, title, null), page, hasNextPage);
+        if (title.length() > 32) {
+            title = title.substring(0, 31);
+        }
+
+        return title;
+    }
+
+    private <T> List<T> getPageItems(List<T> items, int page, int pageSize) {
+        int startIndex = (page * pageSize) - pageSize;
+        int endIndex = Math.min(startIndex + pageSize, items.size());
+        if (startIndex < 0 || startIndex >= items.size()) {
+            return Collections.emptyList();
+        }
+
+        return items.subList(startIndex, endIndex);
     }
 
     private String replacePageNumbers(String line, int page, boolean hasNextPage) {

--- a/src/main/java/me/clip/deluxetags/gui/GUIOptions.java
+++ b/src/main/java/me/clip/deluxetags/gui/GUIOptions.java
@@ -15,6 +15,7 @@ public class GUIOptions {
 	private DisplayItem hasTagItem;
 	private DisplayItem noTagItem;
 	private DisplayItem exitItem;
+	private DisplayItem categoryBackItem;
 	private DisplayItem nextPageItem;
 	private DisplayItem previousPageItem;
 
@@ -50,6 +51,9 @@ public class GUIOptions {
 				case EXIT_ITEM:
 					this.exitItem = config.loadGuiItem(type);
 					break;
+				case CATEGORY_BACK_ITEM:
+					this.categoryBackItem = config.loadGuiItem(type);
+					break;
 				case NEXT_PAGE:
 					this.nextPageItem = config.loadGuiItem(type);
 					break;
@@ -78,6 +82,10 @@ public class GUIOptions {
 
 	public DisplayItem getExitItem() {
 		return exitItem;
+	}
+
+	public DisplayItem getCategoryBackItem() {
+		return categoryBackItem;
 	}
 
 	public DisplayItem getNextPageItem() {

--- a/src/main/java/me/clip/deluxetags/gui/ItemType.java
+++ b/src/main/java/me/clip/deluxetags/gui/ItemType.java
@@ -12,6 +12,7 @@ public enum ItemType {
     HAS_TAG_ITEM(XMaterial.PLAYER_HEAD.parseMaterial()),
     NO_TAG_ITEM(XMaterial.PLAYER_HEAD.parseMaterial()),
     EXIT_ITEM(XMaterial.IRON_DOOR.parseMaterial()),
+    CATEGORY_BACK_ITEM(XMaterial.ARROW.parseMaterial()),
     NEXT_PAGE(XMaterial.PAPER.parseMaterial()),
     PREVIOUS_PAGE(XMaterial.PAPER.parseMaterial()),
     UNKNOWN(null);

--- a/src/main/java/me/clip/deluxetags/gui/TagGUI.java
+++ b/src/main/java/me/clip/deluxetags/gui/TagGUI.java
@@ -14,10 +14,13 @@ public class TagGUI {
 	
 	private static HashMap<String, TagGUI> inGUI;
 	private Map<Integer, String> tags;
+	private Map<Integer, String> categories;
 
 	private Inventory inventory;
 	private final Map<Integer, DisplayItem> items;
 	private final String displayName;
+	private String categoryIdentifier;
+	private boolean categoryMenu;
 	private int slots;
 	private int page;
 	
@@ -26,6 +29,7 @@ public class TagGUI {
 		this.items = new HashMap<>();
 		this.page = page;
 		this.tags = new HashMap<>();
+		this.categories = new HashMap<>();
 	}
 	
 	public int getInventorySize(){
@@ -39,6 +43,9 @@ public class TagGUI {
 	public TagGUI clear() {
 		this.items.clear();
 		this.tags = null;
+		this.categories = null;
+		this.categoryIdentifier = null;
+		this.categoryMenu = false;
 		return this;
 	}
 	
@@ -106,7 +113,7 @@ public class TagGUI {
 	public ItemType getClickedItemType(int slot) {
 		DisplayItem clickedDisplayItem = this.items.get(slot);
 
-		return clickedDisplayItem != null ? clickedDisplayItem.getType() : null;
+		return clickedDisplayItem != null ? clickedDisplayItem.getType() : ItemType.UNKNOWN;
 	}
 
 	public int getPage() {
@@ -127,5 +134,29 @@ public class TagGUI {
 
 	public void setTags(Map<Integer, String> tags) {
 		this.tags = tags;
+	}
+
+	public Map<Integer, String> getCategories() {
+		return categories;
+	}
+
+	public void setCategories(Map<Integer, String> categories) {
+		this.categories = categories;
+	}
+
+	public String getCategoryIdentifier() {
+		return categoryIdentifier;
+	}
+
+	public void setCategoryIdentifier(String categoryIdentifier) {
+		this.categoryIdentifier = categoryIdentifier;
+	}
+
+	public boolean isCategoryMenu() {
+		return categoryMenu;
+	}
+
+	public void setCategoryMenu(boolean categoryMenu) {
+		this.categoryMenu = categoryMenu;
 	}
 }

--- a/src/main/java/me/clip/deluxetags/tags/DeluxeTag.java
+++ b/src/main/java/me/clip/deluxetags/tags/DeluxeTag.java
@@ -19,6 +19,7 @@ public class DeluxeTag {
     private String displayTag;
     private String description;
     private String permission;
+    private String category;
     private int priority;
 
     /**
@@ -30,10 +31,15 @@ public class DeluxeTag {
      * @param description String value representing the description of this tag
      */
     public DeluxeTag(final int priority, @NotNull final String identifier, @NotNull final String displayTag, @NotNull String description) {
+        this(priority, identifier, displayTag, description, DeluxeTagCategory.GENERAL_IDENTIFIER);
+    }
+
+    public DeluxeTag(final int priority, @NotNull final String identifier, @NotNull final String displayTag, @NotNull String description, @NotNull final String category) {
         this.priority = priority;
         this.identifier = identifier;
         this.displayTag = displayTag;
         this.description = description;
+        setCategory(category);
     }
 
     /**
@@ -116,6 +122,29 @@ public class DeluxeTag {
      */
     public void setPriority(final int priority) {
         this.priority = priority;
+    }
+
+    /**
+     * get the category associated with this tag
+     *
+     * @return category identifier String
+     */
+    public @NotNull String getCategory() {
+        return category == null ? DeluxeTagCategory.GENERAL_IDENTIFIER : category;
+    }
+
+    /**
+     * set the category associated with this tag
+     *
+     * @param category category identifier to set for this tag
+     */
+    public void setCategory(@NotNull final String category) {
+        if (category.trim().isEmpty() || category.equalsIgnoreCase(DeluxeTagCategory.ALL_IDENTIFIER)) {
+            this.category = DeluxeTagCategory.GENERAL_IDENTIFIER;
+            return;
+        }
+
+        this.category = category;
     }
 
     /**

--- a/src/main/java/me/clip/deluxetags/tags/DeluxeTagCategory.java
+++ b/src/main/java/me/clip/deluxetags/tags/DeluxeTagCategory.java
@@ -1,0 +1,66 @@
+package me.clip.deluxetags.tags;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.bukkit.Material;
+import org.jetbrains.annotations.NotNull;
+
+public class DeluxeTagCategory {
+
+    public static final String ALL_IDENTIFIER = "all";
+    public static final String GENERAL_IDENTIFIER = "general";
+
+    private final String identifier;
+    private final int order;
+    private final Material material;
+    private final String name;
+    private final List<String> lore;
+    private final String guiName;
+    private final boolean allCategory;
+
+    public DeluxeTagCategory(
+            @NotNull final String identifier,
+            final int order,
+            @NotNull final Material material,
+            @NotNull final String name,
+            @NotNull final List<String> lore,
+            @NotNull final String guiName,
+            final boolean allCategory) {
+        this.identifier = identifier;
+        this.order = order;
+        this.material = material;
+        this.name = name;
+        this.lore = Collections.unmodifiableList(new ArrayList<>(lore));
+        this.guiName = guiName;
+        this.allCategory = allCategory;
+    }
+
+    public @NotNull String getIdentifier() {
+        return identifier;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    public @NotNull Material getMaterial() {
+        return material;
+    }
+
+    public @NotNull String getName() {
+        return name;
+    }
+
+    public @NotNull List<String> getLore() {
+        return lore;
+    }
+
+    public @NotNull String getGuiName() {
+        return guiName;
+    }
+
+    public boolean isAllCategory() {
+        return allCategory;
+    }
+}

--- a/src/main/java/me/clip/deluxetags/tags/DeluxeTagsHandler.java
+++ b/src/main/java/me/clip/deluxetags/tags/DeluxeTagsHandler.java
@@ -21,6 +21,7 @@ public class DeluxeTagsHandler {
     private final DeluxeTags plugin;
 
     private final TreeMap<Integer, DeluxeTag> configTags = new TreeMap<>();
+    private final Map<String, DeluxeTagCategory> categories = new HashMap<>();
     private final Map<UUID, DeluxeTag> playerTags = new HashMap<>();
 
     private final List<UUID> playersUsingDefaultTag = new ArrayList<>();
@@ -132,6 +133,30 @@ public class DeluxeTagsHandler {
     // Tag functions
 
     /**
+     * load this category into the category list.
+     */
+    public void loadCategory(@NotNull final DeluxeTagCategory category) {
+        categories.put(category.getIdentifier(), category);
+    }
+
+    /**
+     * check if a category identifier has been loaded.
+     */
+    public boolean hasCategory(@NotNull final String identifier) {
+        return getCategoryByIdentifier(identifier) != null;
+    }
+
+    /**
+     * get a DeluxeTagCategory by its identifier.
+     */
+    public @Nullable DeluxeTagCategory getCategoryByIdentifier(@NotNull final String identifier) {
+        return categories.values().stream()
+                .filter(category -> category.getIdentifier().equalsIgnoreCase(identifier))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
      * load this tag into the tag list. if a tag with the same priority already exists, it will be overwritten
      */
     public void loadTag(@NotNull final DeluxeTag tag) {
@@ -218,6 +243,24 @@ public class DeluxeTagsHandler {
     }
 
     /**
+     * get list containing all loaded categories in configured order.
+     */
+    public @NotNull List<@NotNull DeluxeTagCategory> getAllCategories() {
+        return categories.values().stream()
+                .sorted(Comparator.comparingInt(DeluxeTagCategory::getOrder).thenComparing(DeluxeTagCategory::getIdentifier))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * get list containing all real categories, excluding the synthetic all-tags category.
+     */
+    public @NotNull List<@NotNull DeluxeTagCategory> getRealCategories() {
+        return getAllCategories().stream()
+                .filter(category -> !category.isAllCategory())
+                .collect(Collectors.toList());
+    }
+
+    /**
      * get a list of all available tag identifiers that have been loaded in increasing order of priority
      * @return empty list if no tags are loaded
      */
@@ -242,6 +285,25 @@ public class DeluxeTagsHandler {
     }
 
     /**
+     * get a list of all available tag identifiers a player has permission for in a category.
+     * @param player Player to get tag identifiers for
+     * @param categoryIdentifier Category identifier to filter by
+     * @return empty list if player doesn't have permission to any tags in that category
+     */
+    public @NotNull List<@NotNull String> getPlayerAvailableTagIdentifiers(@NotNull final Player player, @NotNull final String categoryIdentifier) {
+        if (categoryIdentifier.equalsIgnoreCase(DeluxeTagCategory.ALL_IDENTIFIER)) {
+            return getPlayerAvailableTagIdentifiers(player);
+        }
+
+        return getAllTags().stream()
+                .filter(tag -> tag.getCategory().equalsIgnoreCase(categoryIdentifier))
+                .filter(tag -> tag.hasPermissionToUse(player))
+                .sorted(Comparator.comparingInt(DeluxeTag::getPriority))
+                .map(DeluxeTag::getIdentifier)
+                .collect(Collectors.toList());
+    }
+
+    /**
      * get a list of all tag identifiers that a player can see or use (players can see tags they have permission to use) in increasing order of priority
      * @param player Player to get tag identifiers for
      * @return empty list if player can't see any tags or no tags are loaded
@@ -251,6 +313,53 @@ public class DeluxeTagsHandler {
                 .filter(tag -> tag.hasPermissionToSee(player) || tag.hasPermissionToUse(player))
                 .sorted(Comparator.comparingInt(DeluxeTag::getPriority))
                 .map(DeluxeTag::getIdentifier)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * get a list of all visible tag identifiers in a category.
+     * @param player Player to get tag identifiers for
+     * @param categoryIdentifier Category identifier to filter by
+     * @return empty list if player can't see any tags in that category
+     */
+    public @NotNull List<@NotNull String> getPlayerVisibleTagIdentifiers(@NotNull final Player player, @NotNull final String categoryIdentifier) {
+        if (categoryIdentifier.equalsIgnoreCase(DeluxeTagCategory.ALL_IDENTIFIER)) {
+            return getPlayerVisibleTagIdentifiers(player);
+        }
+
+        return getAllTags().stream()
+                .filter(tag -> tag.getCategory().equalsIgnoreCase(categoryIdentifier))
+                .filter(tag -> tag.hasPermissionToSee(player) || tag.hasPermissionToUse(player))
+                .sorted(Comparator.comparingInt(DeluxeTag::getPriority))
+                .map(DeluxeTag::getIdentifier)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * get all real categories a player can open and that contain at least one visible tag.
+     */
+    public @NotNull List<@NotNull DeluxeTagCategory> getPlayerVisibleCategories(@NotNull final Player player) {
+        return getRealCategories().stream()
+                .filter(category -> !getPlayerVisibleTagIdentifiers(player, category.getIdentifier()).isEmpty())
+                .sorted(Comparator.comparingInt(DeluxeTagCategory::getOrder).thenComparing(DeluxeTagCategory::getIdentifier))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * get categories to show in the selector, including the synthetic all-tags category when useful.
+     */
+    public @NotNull List<@NotNull DeluxeTagCategory> getPlayerSelectableCategories(@NotNull final Player player) {
+        final List<DeluxeTagCategory> visibleCategories = new ArrayList<>(getPlayerVisibleCategories(player));
+
+        if (visibleCategories.size() >= 2) {
+            final DeluxeTagCategory allCategory = getCategoryByIdentifier(DeluxeTagCategory.ALL_IDENTIFIER);
+            if (allCategory != null) {
+                visibleCategories.add(allCategory);
+            }
+        }
+
+        return visibleCategories.stream()
+                .sorted(Comparator.comparingInt(DeluxeTagCategory::getOrder).thenComparing(DeluxeTagCategory::getIdentifier))
                 .collect(Collectors.toList());
     }
 
@@ -304,6 +413,7 @@ public class DeluxeTagsHandler {
      */
     public void unloadData() {
         configTags.clear();
+        categories.clear();
         playerTags.clear();
 
         playersUsingDefaultTag.clear();


### PR DESCRIPTION
- Tags can now be organized into categories.
- The tag GUI now shows and uses those categories.
- Players can browse tags by category instead of seeing one long list.


Categories only show if there are more then 1 category setup AND they have permission to either see or use at least one tag in that category 

eg
```
categories:
  all:
    order: 0
    item: BOOK
    name: '&6All Tags'
    lore:
    - '&7Click to view all available tags'
    gui_name: '&6All Tags'
  general:
    order: 1
    item: NAME_TAG
    name: '&6General'
    lore:
    - '&7Click to view general tags'
    gui_name: '&6General tags'
  epic:
    order: 2
    item: NAME_TAG
    name: <gradient:#ff6b6b:#feca57>Epic Tags</gradient>
    lore:
    - '&7Click to view epic tags'
    - '&7These tags are super epic and cool'
    gui_name: '&aEpic tags'
```

```
  example:
    order: 1
    tag: <gradient:#ff6b6b:#48dbfb>[DeluxeTags]</gradient>
    description: <gradient:#ff0000:#00ff00>MiniMessage is working!</gradient>
    permission: deluxetags.tag.example
    category: general
    ```