### PR TITLE
feat: add per-tag GUI items

### DIFF
--- a/src/main/java/me/clip/deluxetags/DeluxeTags.java
+++ b/src/main/java/me/clip/deluxetags/DeluxeTags.java
@@ -16,6 +16,7 @@ import me.clip.deluxetags.listeners.JoinListener;
 import me.clip.deluxetags.listeners.PlayerListener;
 import me.clip.deluxetags.placeholders.TagPlaceholders;
 import me.clip.deluxetags.tags.DeluxeTag;
+import me.clip.deluxetags.tags.DeluxeTagCategory;
 import me.clip.deluxetags.tags.DeluxeTagsHandler;
 import me.clip.deluxetags.tasks.CleanupTask;
 import me.clip.deluxetags.updater.UpdateChecker;
@@ -260,6 +261,10 @@ public class DeluxeTags extends JavaPlugin {
 	}
 
 	public String setPlaceholders(Player p, String s, DeluxeTag tag) {
+		return setPlaceholders(p, s, tag, DeluxeTagCategory.ALL_IDENTIFIER);
+	}
+
+	public String setPlaceholders(Player p, String s, DeluxeTag tag, String categoryIdentifier) {
 		if (tag == null) {
 			tag = this.getTagsHandler().getPlayerActiveTag(p);
 		}
@@ -271,9 +276,11 @@ public class DeluxeTags extends JavaPlugin {
 		List<String> tags = this.getTagsHandler().getPlayerAvailableTagIdentifiers(p);
 		String tagId = tag.getIdentifier() != null ? tag.getIdentifier() : "";
 		String amount = tags != null ? String.valueOf(tags.size()) : "0";
-		String availability = tag.hasPermissionToUse(p)
-			? Lang.GUI_PLACEHOLDERS_TAG_AVAILABLE.getConfigValue(null)
-			: Lang.GUI_PLACEHOLDERS_TAG_UNAVAILABLE.getConfigValue(null);
+		String categoryAmount = amount;
+		if (categoryIdentifier != null && !categoryIdentifier.trim().isEmpty()) {
+			categoryAmount = String.valueOf(this.getTagsHandler().getPlayerAvailableTagIdentifiers(p, categoryIdentifier).size());
+		}
+		String availability = cfg.getTagAvailabilityPlaceholder(tag.hasPermissionToUse(p));
 
 		s = s
 			.replace("%player%", p.getName())
@@ -288,6 +295,8 @@ public class DeluxeTags extends JavaPlugin {
 			.replace("{deluxetags_description}", tag.getDescription(p))
 			.replace("%deluxetags_amount%", amount)
 			.replace("{deluxetags_amount}", amount)
+			.replace("%deluxetags_category_amount%", categoryAmount)
+			.replace("{deluxetags_category_amount}", categoryAmount)
 			.replace("%deluxetags_available%", availability)
 			.replace("{deluxetags_available}", availability);
 		

--- a/src/main/java/me/clip/deluxetags/config/TagConfig.java
+++ b/src/main/java/me/clip/deluxetags/config/TagConfig.java
@@ -27,6 +27,21 @@ import org.jetbrains.annotations.Nullable;
 
 public class TagConfig {
 
+  private static final String LEGACY_TAG_AVAILABILITY_PLACEHOLDER_PATH = "tag_availability_placeholder";
+  private static final String TAG_AVAILABILITY_PLACEHOLDER_PATH = "gui.tag_availability_placeholder";
+  private static final List<String> TOP_LEVEL_CONFIG_ORDER = Collections.unmodifiableList(Arrays.asList(
+      "use_minimessage",
+      "force_tags",
+      "check_updates",
+      "legacy_hex",
+      "papi_chat",
+      "format_chat",
+      "load_tag_on_join",
+      "gui",
+      "categories",
+      "deluxetags"
+  ));
+
   DeluxeTags plugin;
   FileConfiguration config;
 
@@ -58,7 +73,12 @@ public class TagConfig {
             + "\n    order: 1"
             + "\n    category: general"
             + "\n    tag: '&7[&eVIP&7]'"
-            + "\n    description: 'This tag is awarded by getting VIP'"
+            + "\n    displayname: '&6Tag&f: &6%deluxetags_identifier%'"
+            + "\n    description:"
+            + "\n      - 'This tag is awarded by getting VIP'"
+            + "\n      - '%deluxetags_available%'"
+            + "\n    item: NAME_TAG"
+            + "\n    data: 0"
             + "\n"
             + "\nCreate your categories using the following format:"
             + "\n"
@@ -78,119 +98,130 @@ public class TagConfig {
             + "\n%deluxetags_identifier% - display the players active tag identifier"
             + "\n%deluxetags_tag% - display the players active tag"
             + "\n%deluxetags_description% - display the players active tag description"
-            + "\n%deluxetags_amount% - display the amount of tags a player has access to");
+            + "\n%deluxetags_amount% - display the amount of tags a player has access to"
+            + "\n"
+            + "\nPlaceholders for the tags GUI:"
+            + "\n"
+            + "\n%deluxetags_available% - display whether the player can select the displayed tag"
+            + "\n%deluxetags_category_amount% - display the amount of tags the player has access to in the current category"
+            + "\n"
+            + "\nTag availability placeholder text:"
+            + "\n"
+            + "\ngui:"
+            + "\n  tag_availability_placeholder:"
+            + "\n    has_permission: '&aTag unlocked! Click to select'"
+            + "\n    no_permission: '&cTag locked '");
 
-    config.addDefault("force_tags", false);
-    config.addDefault("check_updates", true);
-    config.addDefault("legacy_hex", false);
-    config.addDefault("use_minimessage", false);
-    config.addDefault("papi_chat", true);
-    config.addDefault("format_chat.enabled", false);
-    config.addDefault("format_chat.format", "{deluxetags_tag} <%1$s> %2$s");
-    if (config.contains("force_tag_on_join")) {
+    addDefault("use_minimessage", false);
+    addDefault("force_tags", false);
+    addDefault("check_updates", true);
+    addDefault("legacy_hex", false);
+    addDefault("papi_chat", true);
+    addDefault("format_chat.enabled", false);
+    addDefault("format_chat.format", "{deluxetags_tag} <%1$s> %2$s");
+    if (config.isSet("force_tag_on_join")) {
       config.set("force_tag_on_join", null);
     }
-    config.addDefault("load_tag_on_join", true);
+    addDefault("load_tag_on_join", true);
+
+    migrateTagAvailabilityPlaceholder(config);
 
     // GUI properties
-    config.addDefault("gui.name", "&6Available tags&f: &6%deluxetags_amount%");
-    config.addDefault("gui.size", 54);
-    config.addDefault("gui.tag_slots", Collections.singletonList("0-35"));
-
-    // Tag Select item
-    config.addDefault("gui.tag_select_item.material", "NAME_TAG");
-    config.addDefault("gui.tag_select_item.data", 0);
-    config.addDefault("gui.tag_select_item.displayname", "&6Tag&f: &6%deluxetags_identifier%");
-    config.addDefault("gui.tag_select_item.lore",
-        Arrays.asList("%deluxetags_tag%", "%deluxetags_description%"));
+    addDefault("gui.tag_availability_placeholder.has_permission", "&aTag unlocked! Click to select");
+    addDefault("gui.tag_availability_placeholder.no_permission", "&cTag locked ");
+    addDefault("gui.name", "&6Available tags&f: &6%deluxetags_amount%");
+    addDefault("gui.size", 54);
+    addDefault("gui.tag_slots", Collections.singletonList("0-35"));
 
     // Tag Visible item
-    config.addDefault("gui.tag_visible_item.material", "NAME_TAG");
-    config.addDefault("gui.tag_visible_item.data", 0);
-    config.addDefault("gui.tag_visible_item.displayname", "&6Tag&f: &6%deluxetags_identifier%");
-    config.addDefault("gui.tag_visible_item.lore",
-        Arrays.asList("%deluxetags_tag%", "%deluxetags_description%", "&7You can see this tag but you can't select it!"));
+    addDefault("gui.tag_visible_item.material", "BARRIER");
+    addDefault("gui.tag_visible_item.data", 0);
 
     // Divider item
-    config.addDefault("gui.divider_item.material", "BLACK_STAINED_GLASS_PANE");
-    config.addDefault("gui.divider_item.data", 0);
-    config.addDefault("gui.divider_item.displayname", "");
-    config.addDefault("gui.divider_item.lore",
+    addDefault("gui.divider_item.material", "BLACK_STAINED_GLASS_PANE");
+    addDefault("gui.divider_item.data", 0);
+    addDefault("gui.divider_item.displayname", "");
+    addDefault("gui.divider_item.lore",
         Collections.emptyList());
     addDefaultUnlessAlternativePathExists("gui.divider_item.slots", Collections.singletonList("36-44"), "gui.divider_item.slot");
 
     // Has Tag item
-    config.addDefault("gui.has_tag_item.material", "PLAYER_HEAD");
-    config.addDefault("gui.has_tag_item.data", 0);
-    config.addDefault("gui.has_tag_item.displayname", "&eCurrent tag&f: &6%deluxetags_identifier%");
-    config.addDefault("gui.has_tag_item.lore",
+    addDefault("gui.has_tag_item.material", "PLAYER_HEAD");
+    addDefault("gui.has_tag_item.data", 0);
+    addDefault("gui.has_tag_item.displayname", "&eCurrent tag&f: &6%deluxetags_identifier%");
+    addDefault("gui.has_tag_item.lore",
         Arrays.asList("%deluxetags_tag%", "Click to remove your current tag"));
     addDefaultUnlessAlternativePathExists("gui.has_tag_item.slot", 49, "gui.has_tag_item.slots");
 
     // No Tag item
-    config.addDefault("gui.no_tag_item.material", "PLAYER_HEAD");
-    config.addDefault("gui.no_tag_item.data", 0);
-    config.addDefault("gui.no_tag_item.displayname", "&cYou don't have a tag set!");
-    config.addDefault("gui.no_tag_item.lore",
+    addDefault("gui.no_tag_item.material", "PLAYER_HEAD");
+    addDefault("gui.no_tag_item.data", 0);
+    addDefault("gui.no_tag_item.displayname", "&cYou don't have a tag set!");
+    addDefault("gui.no_tag_item.lore",
         Collections.singletonList("&7Click a tag above to select one!"));
     addDefaultUnlessAlternativePathExists("gui.no_tag_item.slot", 49,  "gui.no_tag_item.slots");
 
     // Exit item
-    config.addDefault("gui.exit_item.material", "IRON_DOOR");
-    config.addDefault("gui.exit_item.data", 0);
-    config.addDefault("gui.exit_item.displayname", "&cClick to exit");
-    config.addDefault("gui.exit_item.lore",
+    addDefault("gui.exit_item.material", "IRON_DOOR");
+    addDefault("gui.exit_item.data", 0);
+    addDefault("gui.exit_item.displayname", "&cClick to exit");
+    addDefault("gui.exit_item.lore",
         Collections.singletonList("&7Exit the tags menu"));
     addDefaultUnlessAlternativePathExists("gui.exit_item.slots", Arrays.asList(48, 50), "gui.exit_item.slot");
 
     // Category Back item
-    config.addDefault("gui.category_back_item.material", "ARROW");
-    config.addDefault("gui.category_back_item.data", 0);
-    config.addDefault("gui.category_back_item.displayname", "&6Back to categories");
-    config.addDefault("gui.category_back_item.lore",
+    addDefault("gui.category_back_item.material", "ARROW");
+    addDefault("gui.category_back_item.data", 0);
+    addDefault("gui.category_back_item.displayname", "&6Back to categories");
+    addDefault("gui.category_back_item.lore",
         Collections.singletonList("&7Return to category selection"));
     addDefaultUnlessAlternativePathExists("gui.category_back_item.slot", 47, "gui.category_back_item.slots");
 
     // Next Page item
-    config.addDefault("gui.next_page.material", "PAPER");
-    config.addDefault("gui.next_page.data", 0);
-    config.addDefault("gui.next_page.displayname", "&6Next page: %page%");
-    config.addDefault("gui.next_page.lore",
+    addDefault("gui.next_page.material", "PAPER");
+    addDefault("gui.next_page.data", 0);
+    addDefault("gui.next_page.displayname", "&6Next page: %page%");
+    addDefault("gui.next_page.lore",
         Collections.singletonList("&7Move to the next page"));
     addDefaultUnlessAlternativePathExists("gui.next_page.slot", 53, "gui.next_page.slots");
 
     // Previous Page item
-    config.addDefault("gui.previous_page.material", "PAPER");
-    config.addDefault("gui.previous_page.data", 0);
-    config.addDefault("gui.previous_page.displayname", "&6Previous page: %page%");
-    config.addDefault("gui.previous_page.lore",
+    addDefault("gui.previous_page.material", "PAPER");
+    addDefault("gui.previous_page.data", 0);
+    addDefault("gui.previous_page.displayname", "&6Previous page: %page%");
+    addDefault("gui.previous_page.lore",
         Collections.singletonList("&7Move to the previous page"));
     addDefaultUnlessAlternativePathExists("gui.previous_page.slot", 45, "gui.previous_page.slots");
 
     // Category properties
-    config.addDefault("categories.all.order", 0);
-    config.addDefault("categories.all.item", "BOOK");
-    config.addDefault("categories.all.name", "&6All Tags");
-    config.addDefault("categories.all.lore",
+    addDefault("categories.all.order", 0);
+    addDefault("categories.all.item", "BOOK");
+    addDefault("categories.all.name", "&6All Tags");
+    addDefault("categories.all.lore",
         Collections.singletonList("&7Click to view all available tags"));
-    config.addDefault("categories.all.gui_name", "&6All Tags");
+    addDefault("categories.all.gui_name", "&6All Tags");
 
-    config.addDefault("categories.general.order", 1);
-    config.addDefault("categories.general.item", "NAME_TAG");
-    config.addDefault("categories.general.name", "&6General");
-    config.addDefault("categories.general.lore",
+    addDefault("categories.general.order", 1);
+    addDefault("categories.general.item", "NAME_TAG");
+    addDefault("categories.general.name", "&6General");
+    addDefault("categories.general.lore",
         Collections.singletonList("&7Click to view general tags"));
-    config.addDefault("categories.general.gui_name", "&6General tags");
+    addDefault("categories.general.gui_name", "&6General tags");
 
     if (!config.contains("deluxetags")) {
       config.set("deluxetags.example.order", 1);
       config.set("deluxetags.example.category", DeluxeTagCategory.GENERAL_IDENTIFIER);
       config.set("deluxetags.example.tag", "&8[&bDeluxeTags&8]");
-      config.set("deluxetags.example.description", "&cAwarded for using DeluxeTags!");
+      config.set("deluxetags.example.displayname", DeluxeTag.DEFAULT_DISPLAY_NAME);
+      config.set("deluxetags.example.description", Arrays.asList("&cAwarded for using DeluxeTags!", "%deluxetags_available%"));
+      config.set("deluxetags.example.item", "NAME_TAG");
+      config.set("deluxetags.example.data", 0);
       config.set("deluxetags.example.permission", "deluxetags.tag.example");
     }
 
-    migrateTagCategories();
+    migrateTags(config);
+    normalizeTopLevelOrder(config);
+    applySectionComments(config);
 
     config.options().copyDefaults(true);
     plugin.saveConfig();
@@ -205,24 +236,153 @@ public class TagConfig {
    * @param alternativePath alternative path that means original path shouldn't be set
    */
   private void addDefaultUnlessAlternativePathExists(String path, Object value, String alternativePath) {
-    if (!config.contains(alternativePath)) {
-      config.addDefault(path, value);
+    if (!config.isSet(alternativePath)) {
+      addDefault(path, value);
     }
   }
 
-  private void migrateTagCategories() {
+  private void addDefault(String path, Object value) {
+    config.addDefault(path, value);
+    if (!config.isSet(path)) {
+      config.set(path, value);
+    }
+  }
+
+  static void applySectionComments(FileConfiguration config) {
+    config.setComments("use_minimessage", Collections.singletonList("Main Options"));
+    config.setComments("gui", Arrays.asList(null, "GUI layout and buttons"));
+    config.setComments("categories", Arrays.asList(null, "Tag category menus"));
+    config.setComments("deluxetags", Arrays.asList(null, "Tags"));
+  }
+
+  static void migrateTagAvailabilityPlaceholder(FileConfiguration config) {
+    ConfigurationSection legacySection = config.getConfigurationSection(LEGACY_TAG_AVAILABILITY_PLACEHOLDER_PATH);
+    if (legacySection == null) {
+      if (config.isSet(LEGACY_TAG_AVAILABILITY_PLACEHOLDER_PATH)) {
+        config.set(LEGACY_TAG_AVAILABILITY_PLACEHOLDER_PATH, null);
+      }
+      return;
+    }
+
+    for (String key : legacySection.getKeys(false)) {
+      String newPath = TAG_AVAILABILITY_PLACEHOLDER_PATH + "." + key;
+      if (!config.isSet(newPath)) {
+        config.set(newPath, copyConfigValue(legacySection.get(key)));
+      }
+    }
+
+    config.set(LEGACY_TAG_AVAILABILITY_PLACEHOLDER_PATH, null);
+  }
+
+  static void normalizeTopLevelOrder(FileConfiguration config) {
+    Map<String, Object> values = new LinkedHashMap<>();
+    for (String key : config.getKeys(false)) {
+      values.put(key, copyConfigValue(config.get(key)));
+    }
+
+    if (values.isEmpty()) {
+      return;
+    }
+
+    for (String key : new ArrayList<>(values.keySet())) {
+      config.set(key, null);
+    }
+
+    Set<String> restoredKeys = new HashSet<>();
+    for (String key : TOP_LEVEL_CONFIG_ORDER) {
+      if (values.containsKey(key)) {
+        restoreConfigValue(config, key, values.get(key));
+        restoredKeys.add(key);
+      }
+    }
+
+    for (Map.Entry<String, Object> entry : values.entrySet()) {
+      if (!restoredKeys.contains(entry.getKey())) {
+        restoreConfigValue(config, entry.getKey(), entry.getValue());
+      }
+    }
+  }
+
+  private static Object copyConfigValue(Object value) {
+    if (value instanceof ConfigurationSection) {
+      return copyConfigSection((ConfigurationSection) value);
+    }
+
+    return value;
+  }
+
+  private static Map<String, Object> copyConfigSection(ConfigurationSection section) {
+    Map<String, Object> values = new LinkedHashMap<>();
+    for (String key : section.getKeys(false)) {
+      values.put(key, copyConfigValue(section.get(key)));
+    }
+    return values;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void restoreConfigValue(ConfigurationSection section, String path, Object value) {
+    if (value instanceof Map) {
+      section.createSection(path, (Map<?, ?>) value);
+      return;
+    }
+
+    section.set(path, value);
+  }
+
+  static void migrateTags(FileConfiguration config) {
     ConfigurationSection deluxetags = config.getConfigurationSection("deluxetags");
     if (deluxetags == null) {
       return;
     }
 
+    String legacyDisplayName = getLegacyTagItemDisplayName(config);
+    List<String> legacyLore = getLegacyTagItemLore(config);
+    Material legacyMaterial = getLegacyTagItemMaterial(config);
+    short legacyData = getLegacyTagItemData(config);
+
     for (String identifier : deluxetags.getKeys(false)) {
-      String categoryPath = "deluxetags." + identifier + ".category";
+      String basePath = "deluxetags." + identifier;
+      String categoryPath = basePath + ".category";
       String category = config.getString(categoryPath);
       if (category == null || category.trim().isEmpty() || category.equalsIgnoreCase(DeluxeTagCategory.ALL_IDENTIFIER)) {
         config.set(categoryPath, DeluxeTagCategory.GENERAL_IDENTIFIER);
       }
+
+      String descriptionPath = basePath + ".description";
+      List<String> description = loadTagDescriptionLines(config, basePath);
+      if (!legacyLore.isEmpty()) {
+        description = expandLegacyTagLore(legacyLore, description);
+      } else if (!config.isList(descriptionPath)) {
+        description = new ArrayList<>(description);
+      }
+      if (!config.isList(descriptionPath) || !legacyLore.isEmpty()) {
+        config.set(descriptionPath, description);
+      }
+
+      if (!config.contains(basePath + ".displayname")) {
+        config.set(basePath + ".displayname", legacyDisplayName);
+      }
+
+      if (!config.contains(basePath + ".item")) {
+        config.set(basePath + ".item", legacyMaterial == null ? "NAME_TAG" : legacyMaterial.name());
+      }
+
+      if (!config.contains(basePath + ".data")) {
+        config.set(basePath + ".data", (int) legacyData);
+      }
     }
+
+    removeLegacyTagItemDefaults(config);
+  }
+
+  private static void removeLegacyTagItemDefaults(FileConfiguration config) {
+    Material tagVisibleMaterial = getTagVisibleMaterial(config);
+    short tagVisibleData = getTagVisibleData(config);
+
+    config.set("gui.tag_select_item", null);
+    config.set("gui.tag_visible_item", null);
+    config.set("gui.tag_visible_item.material", tagVisibleMaterial.name());
+    config.set("gui.tag_visible_item.data", (int) tagVisibleData);
   }
 
   public boolean formatChat() {
@@ -258,6 +418,13 @@ public class TagConfig {
     return config.getBoolean("force_tags");
   }
 
+  public String getTagAvailabilityPlaceholder(boolean hasPermission) {
+    String path = TAG_AVAILABILITY_PLACEHOLDER_PATH + (hasPermission ? ".has_permission" : ".no_permission");
+    String legacyPath = LEGACY_TAG_AVAILABILITY_PLACEHOLDER_PATH + (hasPermission ? ".has_permission" : ".no_permission");
+    String fallback = hasPermission ? "&aTag unlocked! Click to select" : "&cTag locked ";
+    return config.getString(path, config.getString(legacyPath, fallback));
+  }
+
   public List<Integer> getTagSlots() {
     // Conforms to existing code style but isn't as efficient as it could be due to processing on each call
     return loadSlots("gui.tag_slots", "gui.tag_slots");
@@ -269,6 +436,22 @@ public class TagConfig {
 
   public int getMenuSize() {
     return config.getInt("gui.size", 54);
+  }
+
+  public Material getTagVisibleMaterial() {
+    return getTagVisibleMaterial(config);
+  }
+
+  private static Material getTagVisibleMaterial(FileConfiguration config) {
+    return loadMaterial(config.getString("gui.tag_visible_item.material"), XMaterial.BARRIER.parseMaterial());
+  }
+
+  public short getTagVisibleData() {
+    return getTagVisibleData(config);
+  }
+
+  private static short getTagVisibleData(FileConfiguration config) {
+    return loadData(config, "gui.tag_visible_item.data", (short) 0);
   }
 
   public DisplayItem loadGuiItem(@NotNull final ItemType type) {
@@ -409,33 +592,32 @@ public class TagConfig {
     }
 
     for (String identifier : keys) {
-      String tag = config.getString("deluxetags." + identifier + ".tag");
+      String basePath = "deluxetags." + identifier;
+      String tag = config.getString(basePath + ".tag");
       if (tag == null) {
         plugin.getLogger().log(Level.INFO, "Could not load tag: " + identifier + " because it does not have a display set.");
         continue;
       }
-      String description;
+      String description = loadTagDescription(basePath);
+      String displayName = config.getString(basePath + ".displayname", DeluxeTag.DEFAULT_DISPLAY_NAME);
 
-      if (config.isList("deluxetags." + identifier + ".description")) {
-        description = String.join("\n", config.getStringList("deluxetags." + identifier + ".description"));
-      } else {
-        description = config.getString("deluxetags." + identifier + ".description", "&f");
-      }
-
-      if (!config.contains("deluxetags." + identifier + ".order")) {
+      if (!config.contains(basePath + ".order")) {
         plugin.getLogger().log(Level.INFO, "Could not load tag: " + identifier + " because it does not have an order set.");
         continue;
       }
-      int priority = config.getInt("deluxetags." + identifier + ".order");
+      int priority = config.getInt(basePath + ".order");
 
-      String category = normalizeTagCategory(config.getString("deluxetags." + identifier + ".category", DeluxeTagCategory.GENERAL_IDENTIFIER));
+      String category = normalizeTagCategory(config.getString(basePath + ".category", DeluxeTagCategory.GENERAL_IDENTIFIER));
       if (!category.equalsIgnoreCase(DeluxeTagCategory.GENERAL_IDENTIFIER) && !plugin.getTagsHandler().hasCategory(category)) {
         plugin.getLogger().log(Level.INFO, "Could not find category: " + category + " for tag: " + identifier + ". Using general instead.");
         category = DeluxeTagCategory.GENERAL_IDENTIFIER;
       }
 
-      DeluxeTag t = new DeluxeTag(priority, identifier, tag, description, category);
-      t.setPermission(config.getString("deluxetags." + identifier + ".permission", "deluxetags.tag." + identifier));
+      Material material = loadMaterial(config.getString(basePath + ".item"), XMaterial.NAME_TAG.parseMaterial());
+      short data = loadData(basePath + ".data", (short) 0);
+
+      DeluxeTag t = new DeluxeTag(priority, identifier, tag, description, category, displayName, material, data);
+      t.setPermission(config.getString(basePath + ".permission", "deluxetags.tag." + identifier));
       plugin.getTagsHandler().loadTag(t);
       loaded++;
     }
@@ -444,21 +626,31 @@ public class TagConfig {
   }
 
   public void saveTag(DeluxeTag tag) {
-    saveTag(tag.getPriority(), tag.getIdentifier(), tag.getDisplayTag(), tag.getDescription(), tag.getPermission(), tag.getCategory());
+    saveTag(tag.getPriority(), tag.getIdentifier(), tag.getDisplayTag(), tag.getDescription(), tag.getPermission(), tag.getCategory(), tag.getDisplayName(), tag.getMaterial(), tag.getData());
   }
 
   public void saveTag(int priority, String identifier, String tag, String description, String permission) {
-    saveTag(priority, identifier, tag, description, permission, getSavedCategory(identifier));
+    saveTag(priority, identifier, tag, description, permission, getSavedCategory(identifier), getSavedDisplayName(identifier), getSavedMaterial(identifier), getSavedData(identifier));
   }
 
   public void saveTag(int priority, String identifier, String tag, String description, String permission, String category) {
+    saveTag(priority, identifier, tag, description, permission, category, getSavedDisplayName(identifier), getSavedMaterial(identifier), getSavedData(identifier));
+  }
+
+  public void saveTag(int priority, String identifier, String tag, String description, String permission, String category, String displayName, Material material, short data) {
     config.set("deluxetags." + identifier + ".order", priority);
     config.set("deluxetags." + identifier + ".category", normalizeTagCategory(category));
     config.set("deluxetags." + identifier + ".tag", tag);
     if (description == null) {
       description = "&fDescription for tag " + identifier;
     }
-    config.set("deluxetags." + identifier + ".description", description);
+    if (material == null) {
+      material = XMaterial.NAME_TAG.parseMaterial();
+    }
+    config.set("deluxetags." + identifier + ".displayname", displayName == null ? DeluxeTag.DEFAULT_DISPLAY_NAME : displayName);
+    config.set("deluxetags." + identifier + ".description", serializeDescription(description));
+    config.set("deluxetags." + identifier + ".item", material == null ? "NAME_TAG" : material.name());
+    config.set("deluxetags." + identifier + ".data", (int) data);
     config.set("deluxetags." + identifier + ".permission", permission);
     plugin.saveConfig();
   }
@@ -468,7 +660,88 @@ public class TagConfig {
     plugin.saveConfig();
   }
 
-  private Material loadCategoryMaterial(String materialName, Material fallback) {
+  private String loadTagDescription(String basePath) {
+    return String.join("\n", loadTagDescriptionLines(basePath));
+  }
+
+  private List<String> loadTagDescriptionLines(String basePath) {
+    return loadTagDescriptionLines(config, basePath);
+  }
+
+  private static List<String> loadTagDescriptionLines(FileConfiguration config, String basePath) {
+    String descriptionPath = basePath + ".description";
+    if (config.isList(descriptionPath)) {
+      return new ArrayList<>(config.getStringList(descriptionPath));
+    }
+
+    return serializeDescription(config.getString(descriptionPath, "&f"));
+  }
+
+  private static List<String> serializeDescription(String description) {
+    return Arrays.asList(description.replace("\r\n", "\n").replace("\r", "\n").split("\n", -1));
+  }
+
+  private static List<String> expandLegacyTagLore(List<String> legacyLore, List<String> description) {
+    List<String> expanded = new ArrayList<>();
+    String joinedDescription = String.join("\n", description);
+
+    for (String line : legacyLore) {
+      if (line.equals("%deluxetags_description%") || line.equals("{deluxetags_description}")) {
+        expanded.addAll(description);
+        continue;
+      }
+
+      if (line.contains("%deluxetags_description%") || line.contains("{deluxetags_description}")) {
+        String expandedLine = line
+            .replace("%deluxetags_description%", joinedDescription)
+            .replace("{deluxetags_description}", joinedDescription);
+        expanded.addAll(serializeDescription(expandedLine));
+        continue;
+      }
+
+      expanded.add(line);
+    }
+
+    return expanded;
+  }
+
+  private static String getLegacyTagItemDisplayName(FileConfiguration config) {
+    return config.getString("gui.tag_select_item.displayname", DeluxeTag.DEFAULT_DISPLAY_NAME);
+  }
+
+  private static List<String> getLegacyTagItemLore(FileConfiguration config) {
+    if (!config.isList("gui.tag_select_item.lore")) {
+      return Collections.emptyList();
+    }
+
+    return config.getStringList("gui.tag_select_item.lore");
+  }
+
+  private static Material getLegacyTagItemMaterial(FileConfiguration config) {
+    return loadMaterial(config.getString("gui.tag_select_item.material"), XMaterial.NAME_TAG.parseMaterial());
+  }
+
+  private static short getLegacyTagItemData(FileConfiguration config) {
+    return loadData(config, "gui.tag_select_item.data", (short) 0);
+  }
+
+  private String getSavedDisplayName(String identifier) {
+    return config.getString("deluxetags." + identifier + ".displayname", DeluxeTag.DEFAULT_DISPLAY_NAME);
+  }
+
+  private Material getSavedMaterial(String identifier) {
+    return loadMaterial(config.getString("deluxetags." + identifier + ".item"), XMaterial.NAME_TAG.parseMaterial());
+  }
+
+  private short getSavedData(String identifier) {
+    return loadData("deluxetags." + identifier + ".data", (short) 0);
+  }
+
+  private static Material loadCategoryMaterial(String materialName, Material fallback) {
+    return loadMaterial(materialName, fallback);
+  }
+
+  private static Material loadMaterial(String materialName, Material fallback) {
     if (fallback == null) {
       fallback = Material.NAME_TAG;
     }
@@ -480,6 +753,22 @@ public class TagConfig {
     try {
       Material material = XMaterial.matchXMaterial(materialName.toUpperCase(Locale.ROOT)).get().parseMaterial();
       return material == null ? fallback : material;
+    } catch (Exception e) {
+      return fallback;
+    }
+  }
+
+  private short loadData(String path, short fallback) {
+    return loadData(config, path, fallback);
+  }
+
+  private static short loadData(FileConfiguration config, String path, short fallback) {
+    try {
+      if (config.isInt(path)) {
+        return (short) config.getInt(path);
+      }
+
+      return Short.parseShort(config.getString(path, Short.toString(fallback)));
     } catch (Exception e) {
       return fallback;
     }

--- a/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
+++ b/src/main/java/me/clip/deluxetags/gui/GUIHandler.java
@@ -9,12 +9,14 @@ import me.clip.deluxetags.tags.DeluxeTagCategory;
 import me.clip.deluxetags.utils.ItemUtils;
 import me.clip.deluxetags.utils.MsgUtils;
 import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public class GUIHandler implements Listener {
@@ -100,7 +102,7 @@ public class GUIHandler implements Listener {
                     openTagMenu(p, gui.getCategoryIdentifier(), gui.getPage()-1);
                 }
                 break;
-            case TAG_SELECT_ITEM:
+            case CATEGORY_ITEM:
                 if (gui.isCategoryMenu()) {
                     Map<Integer, String> categories;
                     try {
@@ -127,7 +129,8 @@ public class GUIHandler implements Listener {
                     openTagMenu(p, categoryId, 1);
                     break;
                 }
-
+                break;
+            case TAG_ITEM:
                 Map<Integer, String> tags;
                 try {
                     tags = gui.getTags();
@@ -228,7 +231,7 @@ public class GUIHandler implements Listener {
         page = clampPage(page, pages);
         boolean hasNextPage = page < pages;
 
-        String title = prepareTitle(p, options.getMenuName(), page, hasNextPage);
+        String title = prepareTitle(p, options.getMenuName(), page, hasNextPage, DeluxeTagCategory.ALL_IDENTIFIER);
         int menuSlots = options.getMenuSize();
 
         TagGUI gui = new TagGUI(title, page).setSlots(menuSlots);
@@ -246,14 +249,14 @@ public class GUIHandler implements Listener {
             categorySlots.put(tagSlot, category.getIdentifier());
 
             DisplayItem categoryDisplayItem = new DisplayItem(
-                ItemType.TAG_SELECT_ITEM,
+                ItemType.CATEGORY_ITEM,
                 ItemUtils.createItem(category.getMaterial(), (short) 0, category.getName(), category.getLore()),
                 Collections.singletonList(tagSlot)
             );
             ItemMeta categoryItemMeta = categoryDisplayItem.getItemStack().getItemMeta();
             if (categoryItemMeta != null) {
-                categoryItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(categoryDisplayItem.getName(), page, hasNextPage), null));
-                categoryItemMeta.setLore(processLore(categoryDisplayItem.getLore(), p, null, page, hasNextPage));
+                categoryItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(categoryDisplayItem.getName(), page, hasNextPage), null, category.getIdentifier()));
+                categoryItemMeta.setLore(processLore(categoryDisplayItem.getLore(), p, null, page, hasNextPage, category.getIdentifier()));
                 categoryDisplayItem.getItemStack().setItemMeta(categoryItemMeta);
             }
             gui.addDisplayItem(categoryDisplayItem);
@@ -262,7 +265,7 @@ public class GUIHandler implements Listener {
         }
         gui.setCategories(categorySlots);
 
-        addStaticMenuItems(gui, p, page, hasNextPage);
+        addStaticMenuItems(gui, p, page, hasNextPage, DeluxeTagCategory.ALL_IDENTIFIER);
         gui.setPage(page);
         gui.openInventory(p);
         return true;
@@ -294,7 +297,7 @@ public class GUIHandler implements Listener {
         boolean hasNextPage = page < pages;
 
         DeluxeTagCategory category = plugin.getTagsHandler().getCategoryByIdentifier(categoryIdentifier);
-        String title = prepareTitle(p, category != null ? category.getGuiName() : options.getMenuName(), page, hasNextPage);
+        String title = prepareTitle(p, category != null ? category.getGuiName() : options.getMenuName(), page, hasNextPage, categoryIdentifier);
 
         int menuSlots = options.getMenuSize();
 
@@ -303,6 +306,7 @@ public class GUIHandler implements Listener {
 
         ids = getPageItems(ids, page, tagSlots.size());
 
+        DeluxeTag currentTag = plugin.getTagsHandler().getPlayerActiveTag(p);
         int idIndex = 0;
         Map<Integer, String> tags = new HashMap<>();
         for (int tagSlot: tagSlots) {
@@ -319,12 +323,15 @@ public class GUIHandler implements Listener {
             }
 
             // Adds Tag Item to Menu
-            DisplayItem tagDisplayItem = new DisplayItem(tag.hasPermissionToUse(p) ? options.getTagSelectItem() : options.getTagVisibleItem());
+            DisplayItem tagDisplayItem = createTagDisplayItem(p, options, tag, tagSlot);
             ItemMeta tagItemMeta = tagDisplayItem.getItemStack().getItemMeta();
             if (tagItemMeta != null) {
-                tagItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(tagDisplayItem.getName(), page, hasNextPage), tag));
-                tagItemMeta.setLore(processLore(tagDisplayItem.getLore(), p, tag, page, hasNextPage));
+                tagItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(tagDisplayItem.getName(), page, hasNextPage), tag, categoryIdentifier));
+                tagItemMeta.setLore(processLore(tagDisplayItem.getLore(), p, tag, page, hasNextPage, categoryIdentifier));
                 tagDisplayItem.getItemStack().setItemMeta(tagItemMeta);
+            }
+            if (isSelectedTag(currentTag, tag)) {
+                applySelectedGlow(tagDisplayItem.getItemStack());
             }
             tagDisplayItem.setSlots(Collections.singletonList(tagSlot));
             gui.addDisplayItem(tagDisplayItem);
@@ -333,21 +340,21 @@ public class GUIHandler implements Listener {
         }
         gui.setTags(tags);
 
-        addStaticMenuItems(gui, p, page, hasNextPage);
+        addStaticMenuItems(gui, p, page, hasNextPage, categoryIdentifier);
         gui.setPage(page);
         gui.openInventory(p);
         return true;
     }
 
-    private void addStaticMenuItems(TagGUI gui, Player p, int page, boolean hasNextPage) {
+    private void addStaticMenuItems(TagGUI gui, Player p, int page, boolean hasNextPage, String categoryIdentifier) {
         GUIOptions options = plugin.getGuiOptions();
 
         // Adds Divider Item to Menu
         DisplayItem dividerDisplayItem = new DisplayItem(options.getDividerItem());
         ItemMeta dividerItemMeta = dividerDisplayItem.getItemStack().getItemMeta();
         if (dividerItemMeta != null) {
-            dividerItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(dividerDisplayItem.getName(), page, hasNextPage), null));
-            dividerItemMeta.setLore(processLore(dividerDisplayItem.getLore(), p, null, page, hasNextPage));
+            dividerItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(dividerDisplayItem.getName(), page, hasNextPage), null, categoryIdentifier));
+            dividerItemMeta.setLore(processLore(dividerDisplayItem.getLore(), p, null, page, hasNextPage, categoryIdentifier));
             dividerDisplayItem.getItemStack().setItemMeta(dividerItemMeta);
         }
         gui.addDisplayItem(dividerDisplayItem);
@@ -366,8 +373,8 @@ public class GUIHandler implements Listener {
         DisplayItem infoDisplayItem = new DisplayItem(currentTagItem);
         ItemMeta infoItemMeta = infoDisplayItem.getItemStack().getItemMeta();
         if (infoItemMeta != null) {
-            infoItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(infoDisplayItem.getName(), page, hasNextPage), null));
-            infoItemMeta.setLore(processLore(infoDisplayItem.getLore(), p, null, page, hasNextPage));
+            infoItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(infoDisplayItem.getName(), page, hasNextPage), null, categoryIdentifier));
+            infoItemMeta.setLore(processLore(infoDisplayItem.getLore(), p, null, page, hasNextPage, categoryIdentifier));
             infoDisplayItem.getItemStack().setItemMeta(infoItemMeta);
         }
         gui.addDisplayItem(infoDisplayItem);
@@ -376,8 +383,8 @@ public class GUIHandler implements Listener {
         DisplayItem exitDisplayItem = new DisplayItem(options.getExitItem());
         ItemMeta exitItemMeta = exitDisplayItem.getItemStack().getItemMeta();
         if (exitItemMeta != null) {
-            exitItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(exitDisplayItem.getName(), page, hasNextPage), null));
-            exitItemMeta.setLore(processLore(exitDisplayItem.getLore(), p, null, page, hasNextPage));
+            exitItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(exitDisplayItem.getName(), page, hasNextPage), null, categoryIdentifier));
+            exitItemMeta.setLore(processLore(exitDisplayItem.getLore(), p, null, page, hasNextPage, categoryIdentifier));
             exitDisplayItem.getItemStack().setItemMeta(exitItemMeta);
         }
         gui.addDisplayItem(exitDisplayItem);
@@ -387,8 +394,8 @@ public class GUIHandler implements Listener {
             DisplayItem categoryBackDisplayItem = new DisplayItem(options.getCategoryBackItem());
             ItemMeta categoryBackItemMeta = categoryBackDisplayItem.getItemStack().getItemMeta();
             if (categoryBackItemMeta != null) {
-                categoryBackItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(categoryBackDisplayItem.getName(), page, hasNextPage), null));
-                categoryBackItemMeta.setLore(processLore(categoryBackDisplayItem.getLore(), p, null, page, hasNextPage));
+                categoryBackItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(categoryBackDisplayItem.getName(), page, hasNextPage), null, categoryIdentifier));
+                categoryBackItemMeta.setLore(processLore(categoryBackDisplayItem.getLore(), p, null, page, hasNextPage, categoryIdentifier));
                 categoryBackDisplayItem.getItemStack().setItemMeta(categoryBackItemMeta);
             }
             gui.addDisplayItem(categoryBackDisplayItem);
@@ -399,8 +406,8 @@ public class GUIHandler implements Listener {
             DisplayItem previousPageDisplayItem = new DisplayItem(options.getPreviousPageItem());
             ItemMeta previousPageItemMeta = previousPageDisplayItem.getItemStack().getItemMeta();
             if (previousPageItemMeta != null) {
-                previousPageItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(previousPageDisplayItem.getName(), page, hasNextPage), null));
-                previousPageItemMeta.setLore(processLore(previousPageDisplayItem.getLore(), p, null, page, hasNextPage));
+                previousPageItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(previousPageDisplayItem.getName(), page, hasNextPage), null, categoryIdentifier));
+                previousPageItemMeta.setLore(processLore(previousPageDisplayItem.getLore(), p, null, page, hasNextPage, categoryIdentifier));
                 previousPageDisplayItem.getItemStack().setItemMeta(previousPageItemMeta);
             }
             gui.addDisplayItem(previousPageDisplayItem);
@@ -411,8 +418,8 @@ public class GUIHandler implements Listener {
             DisplayItem nextPageDisplayItem = new DisplayItem(options.getNextPageItem());
             ItemMeta nextPageItemMeta = nextPageDisplayItem.getItemStack().getItemMeta();
             if (nextPageItemMeta != null) {
-                nextPageItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(nextPageDisplayItem.getName(), page, hasNextPage), null));
-                nextPageItemMeta.setLore(processLore(nextPageDisplayItem.getLore(), p, null, page, hasNextPage));
+                nextPageItemMeta.setDisplayName(plugin.setPlaceholders(p, replacePageNumbers(nextPageDisplayItem.getName(), page, hasNextPage), null, categoryIdentifier));
+                nextPageItemMeta.setLore(processLore(nextPageDisplayItem.getLore(), p, null, page, hasNextPage, categoryIdentifier));
                 nextPageDisplayItem.getItemStack().setItemMeta(nextPageItemMeta);
             }
             gui.addDisplayItem(nextPageDisplayItem);
@@ -438,6 +445,52 @@ public class GUIHandler implements Listener {
         return plugin.getTagsHandler().getPlayerVisibleCategories(player).size() >= 2;
     }
 
+    private DisplayItem createTagDisplayItem(Player player, GUIOptions options, DeluxeTag tag, int slot) {
+        boolean canSelect = tag.hasPermissionToUse(player);
+        Material material = canSelect ? tag.getMaterial() : options.getTagVisibleMaterial();
+        short data = canSelect ? tag.getData() : options.getTagVisibleData();
+        if (material == null) {
+            material = Material.NAME_TAG;
+        }
+
+        return new DisplayItem(
+            canSelect ? ItemType.TAG_ITEM : ItemType.TAG_VISIBLE_ITEM,
+            ItemUtils.createItem(material, data, tag.getDisplayName(), splitLoreLines(tag.getDescription())),
+            Collections.singletonList(slot)
+        );
+    }
+
+    private List<String> splitLoreLines(String lore) {
+        return Arrays.asList(lore.replace("\r\n", "\n").replace("\r", "\n").split("\n", -1));
+    }
+
+    private boolean isSelectedTag(DeluxeTag currentTag, DeluxeTag displayedTag) {
+        return currentTag != null && currentTag.getIdentifier().equalsIgnoreCase(displayedTag.getIdentifier());
+    }
+
+    private void applySelectedGlow(ItemStack itemStack) {
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        if (itemMeta == null) {
+            return;
+        }
+
+        Enchantment enchantment = Enchantment.getByName("DURABILITY");
+        if (enchantment == null) {
+            enchantment = Enchantment.getByName("UNBREAKING");
+        }
+
+        if (enchantment == null) {
+            return;
+        }
+
+        itemMeta.addEnchant(enchantment, 1, true);
+        try {
+            itemMeta.addItemFlags(ItemFlag.valueOf("HIDE_ENCHANTS"));
+        } catch (IllegalArgumentException ignored) {
+        }
+        itemStack.setItemMeta(itemMeta);
+    }
+
     private int clampPage(int page, int pages) {
         if (pages <= 0) {
             return 1;
@@ -450,12 +503,12 @@ public class GUIHandler implements Listener {
         return Math.min(page, pages);
     }
 
-    private String prepareTitle(Player player, String title, int page, boolean hasNextPage) {
+    private String prepareTitle(Player player, String title, int page, boolean hasNextPage, String categoryIdentifier) {
         if (title == null) {
             title = "";
         }
 
-        title = replacePageNumbers(plugin.setPlaceholders(player, title, null), page, hasNextPage);
+        title = replacePageNumbers(plugin.setPlaceholders(player, title, null, categoryIdentifier), page, hasNextPage);
         if (title.length() > 32) {
             title = title.substring(0, 31);
         }
@@ -489,13 +542,13 @@ public class GUIHandler implements Listener {
         return line;
     }
 
-    private List<String> processLore(List<String> originalLore, Player player, DeluxeTag tag, int page, boolean hasNextPage) {
+    private List<String> processLore(List<String> originalLore, Player player, DeluxeTag tag, int page, boolean hasNextPage, String categoryIdentifier) {
         List<String> processedLore = null;
 
         if (originalLore != null && !originalLore.isEmpty()) {
             processedLore = new ArrayList<>();
             for (String line : originalLore) {
-                line = replacePageNumbers(plugin.setPlaceholders(player, line, tag), page, hasNextPage);
+                line = replacePageNumbers(plugin.setPlaceholders(player, line, tag, categoryIdentifier), page, hasNextPage);
                 if (line.contains("\n")) {
                     processedLore.addAll(Arrays.asList(line.split("\n")));
                 } else {

--- a/src/main/java/me/clip/deluxetags/gui/GUIOptions.java
+++ b/src/main/java/me/clip/deluxetags/gui/GUIOptions.java
@@ -2,6 +2,7 @@ package me.clip.deluxetags.gui;
 
 import me.clip.deluxetags.DeluxeTags;
 import me.clip.deluxetags.config.TagConfig;
+import org.bukkit.Material;
 
 import java.util.List;
 
@@ -9,8 +10,8 @@ public class GUIOptions {
 	private final String menuName;
 	private int menuSize;
 	private List<Integer> tagSlots;
-	private DisplayItem tagSelectItem;
-	private DisplayItem tagVisibleItem;
+	private Material tagVisibleMaterial;
+	private short tagVisibleData;
 	private DisplayItem dividerItem;
 	private DisplayItem hasTagItem;
 	private DisplayItem noTagItem;
@@ -30,15 +31,11 @@ public class GUIOptions {
 		}
 
 		tagSlots = config.getTagSlots();
+		tagVisibleMaterial = config.getTagVisibleMaterial();
+		tagVisibleData = config.getTagVisibleData();
 
 		for (ItemType type : ItemType.getCached()) {
 			switch (type) {
-				case TAG_SELECT_ITEM:
-					this.tagSelectItem = config.loadGuiItem(type);
-					break;
-				case TAG_VISIBLE_ITEM:
-					this.tagVisibleItem = config.loadGuiItem(type);
-					break;
 				case DIVIDER_ITEM:
 					this.dividerItem = config.loadGuiItem(type);
 					break;
@@ -64,12 +61,16 @@ public class GUIOptions {
 		}
 	}
 
-	public DisplayItem getTagSelectItem() {
-		return tagSelectItem;
-	}
-
 	public DisplayItem getDividerItem() {
 		return dividerItem;
+	}
+
+	public Material getTagVisibleMaterial() {
+		return tagVisibleMaterial;
+	}
+
+	public short getTagVisibleData() {
+		return tagVisibleData;
 	}
 
 	public DisplayItem getHasTagItem() {
@@ -94,10 +95,6 @@ public class GUIOptions {
 
 	public DisplayItem getPreviousPageItem() {
 		return previousPageItem;
-	}
-
-	public DisplayItem getTagVisibleItem() {
-		return tagVisibleItem;
 	}
 
 	public String getMenuName() {

--- a/src/main/java/me/clip/deluxetags/gui/ItemType.java
+++ b/src/main/java/me/clip/deluxetags/gui/ItemType.java
@@ -6,8 +6,9 @@ import java.util.HashMap;
 import org.bukkit.Material;
 
 public enum ItemType {
-    TAG_SELECT_ITEM(XMaterial.NAME_TAG.parseMaterial()),
-    TAG_VISIBLE_ITEM(XMaterial.NAME_TAG.parseMaterial()),
+    CATEGORY_ITEM(null),
+    TAG_ITEM(null),
+    TAG_VISIBLE_ITEM(XMaterial.BARRIER.parseMaterial()),
     DIVIDER_ITEM(XMaterial.WHITE_STAINED_GLASS_PANE.parseMaterial()),
     HAS_TAG_ITEM(XMaterial.PLAYER_HEAD.parseMaterial()),
     NO_TAG_ITEM(XMaterial.PLAYER_HEAD.parseMaterial()),

--- a/src/main/java/me/clip/deluxetags/tags/DeluxeTag.java
+++ b/src/main/java/me/clip/deluxetags/tags/DeluxeTag.java
@@ -2,6 +2,7 @@ package me.clip.deluxetags.tags;
 
 import me.clip.deluxetags.DeluxeTags;
 import me.clip.placeholderapi.PlaceholderAPI;
+import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -14,12 +15,17 @@ import org.jetbrains.annotations.Nullable;
  */
 public class DeluxeTag {
 
+    public static final String DEFAULT_DISPLAY_NAME = "&6Tag&f: &6%deluxetags_identifier%";
+
     private final String identifier;
 
     private String displayTag;
+    private String displayName;
     private String description;
     private String permission;
     private String category;
+    private Material material;
+    private short data;
     private int priority;
 
     /**
@@ -35,10 +41,38 @@ public class DeluxeTag {
     }
 
     public DeluxeTag(final int priority, @NotNull final String identifier, @NotNull final String displayTag, @NotNull String description, @NotNull final String category) {
+        this(priority, identifier, displayTag, description, category, DEFAULT_DISPLAY_NAME, null, (short) 0);
+    }
+
+    public DeluxeTag(
+        final int priority,
+        @NotNull final String identifier,
+        @NotNull final String displayTag,
+        @NotNull String description,
+        @NotNull final String category,
+        @Nullable final Material material,
+        final short data
+    ) {
+        this(priority, identifier, displayTag, description, category, DEFAULT_DISPLAY_NAME, material, data);
+    }
+
+    public DeluxeTag(
+        final int priority,
+        @NotNull final String identifier,
+        @NotNull final String displayTag,
+        @NotNull String description,
+        @NotNull final String category,
+        @NotNull final String displayName,
+        @Nullable final Material material,
+        final short data
+    ) {
         this.priority = priority;
         this.identifier = identifier;
         this.displayTag = displayTag;
+        this.displayName = displayName;
         this.description = description;
+        this.material = material;
+        this.data = data;
         setCategory(category);
     }
 
@@ -76,6 +110,24 @@ public class DeluxeTag {
      */
     public @NotNull String getDisplayTag(final @Nullable OfflinePlayer player) {
         return DeluxeTags.papi() ? PlaceholderAPI.setPlaceholders(player, displayTag) : displayTag;
+    }
+
+    /**
+     * get the GUI display name of this DeluxeTag
+     *
+     * @return GUI display name String
+     */
+    public @NotNull String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * set the GUI display name for this DeluxeTag
+     *
+     * @param displayName new GUI display name String
+     */
+    public void setDisplayName(@NotNull final String displayName) {
+        this.displayName = displayName;
     }
 
     /**
@@ -145,6 +197,42 @@ public class DeluxeTag {
         }
 
         this.category = category;
+    }
+
+    /**
+     * get the material used for this tag in the GUI
+     *
+     * @return tag GUI material, or null to use the configured fallback
+     */
+    public @Nullable Material getMaterial() {
+        return material;
+    }
+
+    /**
+     * set the material used for this tag in the GUI
+     *
+     * @param material material to display for this tag
+     */
+    public void setMaterial(@Nullable final Material material) {
+        this.material = material;
+    }
+
+    /**
+     * get the durability/data value used for this tag in the GUI
+     *
+     * @return tag GUI data value
+     */
+    public short getData() {
+        return data;
+    }
+
+    /**
+     * set the durability/data value used for this tag in the GUI
+     *
+     * @param data data value to display for this tag
+     */
+    public void setData(final short data) {
+        this.data = data;
     }
 
     /**

--- a/src/test/java/me/clip/deluxetags/config/TagConfigTest.java
+++ b/src/test/java/me/clip/deluxetags/config/TagConfigTest.java
@@ -1,0 +1,120 @@
+package me.clip.deluxetags.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.Test;
+
+public class TagConfigTest {
+
+  @Test
+  public void normalizesMigratedConfigTopLevelOrder() {
+    YamlConfiguration config = new YamlConfiguration();
+    config.set("deluxetags.vip.order", 1);
+    config.set("deluxetags.vip.tag", "&6VIP");
+    config.set("categories.general.order", 1);
+    config.set("gui.name", "&6Tags");
+    config.set("load_tag_on_join", true);
+    config.set("format_chat.enabled", false);
+    config.set("format_chat.format", "{deluxetags_tag} <%1$s> %2$s");
+    config.set("papi_chat", true);
+    config.set("legacy_hex", false);
+    config.set("check_updates", true);
+    config.set("force_tags", false);
+    config.set("use_minimessage", false);
+    config.set("tag_availability_placeholder.has_permission", "&aAllowed");
+    config.set("tag_availability_placeholder.no_permission", "&cNope");
+    config.set("custom_section.enabled", true);
+
+    TagConfig.migrateTagAvailabilityPlaceholder(config);
+    TagConfig.normalizeTopLevelOrder(config);
+
+    assertEquals(Arrays.asList(
+        "use_minimessage",
+        "force_tags",
+        "check_updates",
+        "legacy_hex",
+        "papi_chat",
+        "format_chat",
+        "load_tag_on_join",
+        "gui",
+        "categories",
+        "deluxetags",
+        "custom_section"
+    ), new ArrayList<>(config.getKeys(false)));
+    assertFalse(config.isSet("tag_availability_placeholder"));
+    assertEquals("&aAllowed", config.getString("gui.tag_availability_placeholder.has_permission"));
+    assertEquals("&cNope", config.getString("gui.tag_availability_placeholder.no_permission"));
+  }
+
+  @Test
+  public void keepsExistingGuiAvailabilityPlaceholderDuringLegacyMigration() {
+    YamlConfiguration config = new YamlConfiguration();
+    config.set("gui.tag_availability_placeholder.has_permission", "&aCurrent");
+    config.set("tag_availability_placeholder.has_permission", "&aLegacy");
+
+    TagConfig.migrateTagAvailabilityPlaceholder(config);
+
+    assertEquals("&aCurrent", config.getString("gui.tag_availability_placeholder.has_permission"));
+    assertFalse(config.isSet("tag_availability_placeholder"));
+  }
+
+  @Test
+  public void migratesLegacyTagItemConfigIntoEachTag() {
+    YamlConfiguration config = new YamlConfiguration();
+    config.set("gui.tag_select_item.material", "DIAMOND");
+    config.set("gui.tag_select_item.data", 3);
+    config.set("gui.tag_select_item.displayname", "&6Legacy tag &f%deluxetags_identifier%");
+    config.set("gui.tag_select_item.lore", Arrays.asList(
+        "%deluxetags_tag%",
+        "%deluxetags_description%",
+        "&7Click to select"
+    ));
+    config.set("gui.tag_visible_item.material", "BARRIER");
+    config.set("gui.tag_visible_item.data", 0);
+    config.set("gui.tag_visible_item.displayname", "&cLocked legacy item");
+    config.set("gui.tag_visible_item.lore", Arrays.asList("&7You can see this tag"));
+    config.set("deluxetags.vip.order", 1);
+    config.set("deluxetags.vip.category", "all");
+    config.set("deluxetags.vip.tag", "&6VIP");
+    config.set("deluxetags.vip.description", "&7Legacy description");
+
+    TagConfig.migrateTags(config);
+
+    assertEquals("general", config.getString("deluxetags.vip.category"));
+    assertEquals("&6Legacy tag &f%deluxetags_identifier%", config.getString("deluxetags.vip.displayname"));
+    assertEquals(Arrays.asList(
+        "%deluxetags_tag%",
+        "&7Legacy description",
+        "&7Click to select"
+    ), config.getStringList("deluxetags.vip.description"));
+    assertEquals("DIAMOND", config.getString("deluxetags.vip.item"));
+    assertEquals(3, config.getInt("deluxetags.vip.data"));
+    assertFalse(config.isSet("gui.tag_select_item"));
+    assertEquals("BARRIER", config.getString("gui.tag_visible_item.material"));
+    assertEquals(0, config.getInt("gui.tag_visible_item.data"));
+    assertFalse(config.isSet("gui.tag_visible_item.displayname"));
+    assertFalse(config.isSet("gui.tag_visible_item.lore"));
+  }
+
+  @Test
+  public void addsSectionCommentsToSavedConfig() {
+    YamlConfiguration config = new YamlConfiguration();
+    config.set("use_minimessage", false);
+    config.set("gui.name", "&6Tags");
+    config.set("categories.general.order", 1);
+    config.set("deluxetags.vip.order", 1);
+
+    TagConfig.applySectionComments(config);
+
+    String yaml = config.saveToString();
+    assertTrue(yaml.contains("# Main Options\nuse_minimessage: false"));
+    assertTrue(yaml.contains("use_minimessage: false\n\n# GUI layout and buttons\ngui:"));
+    assertTrue(yaml.contains("  name: '&6Tags'\n\n# Tag category menus\ncategories:"));
+    assertTrue(yaml.contains("  order: 1\n\n# Tags\ndeluxetags:"));
+  }
+}


### PR DESCRIPTION
## Summary

This adds per-tag GUI customization so each tag can control how it appears in the tags menu instead of relying on one shared GUI item config.

## User-facing changes

Server owners can now configure each tag with its own:

- GUI display name
- Description/lore lines
- Item material
- Item data value

Example tag configs can now include:

```yaml
displayname: '&6Tag&f: &6%deluxetags_identifier%'
description:
  - 'This tag is awarded by getting VIP'
  - '%deluxetags_available%'
item: NAME_TAG
data: 0
```

The active selected tag now gets a visual glow in the GUI, making it easier for players to see which tag they currently have selected.
The `%deluxetags_available%` GUI placeholder is now configurable under:
```yaml
gui:
  tag_availability_placeholder:
    has_permission: '&aTag unlocked! Click to select'
    no_permission: '&cTag locked '
```
    
Existing configs are migrated automatically:
Old `gui.tag_select_item` settings are copied into each existing tag.
Old single-line tag descriptions are converted into lore lists.
Existing custom config sections are preserved.