### PR TITLE
feat(updater): switch over to modrinth for update checking

### DIFF
--- a/src/main/java/me/clip/deluxetags/DeluxeTags.java
+++ b/src/main/java/me/clip/deluxetags/DeluxeTags.java
@@ -113,30 +113,7 @@ public class DeluxeTags extends JavaPlugin {
 		}
 		
 		if (cfg.checkUpdates()) {
-			UpdateChecker updater = new UpdateChecker(this);
-			updater.fetch();
-		
-			if (updater.hasUpdateAvailable()) {
-				getLogger().info("----------------------------");
-				getLogger().info("     DeluxeTags Updater");
-				getLogger().info(" ");
-				getLogger().info("An update for DeluxeThat has been found!");
-				getLogger().info("DeluxeTags " + updater.getSpigotVersion());
-				getLogger().info("You are running " + getDescription().getVersion());
-				getLogger().info(" ");
-				getLogger().info("Download at https://www.spigotmc.org/resources/deluxetags.4390/");
-				getLogger().info("----------------------------");
-
-			} else {
-				getLogger().info("----------------------------");
-				getLogger().info("     DeluxeTags Updater");
-				getLogger().info(" ");
-				getLogger().info("You are running " + getDescription().getVersion());
-				getLogger().info("The latest version");
-				getLogger().info("of DeluxeTags!");
-				getLogger().info(" ");
-				getLogger().info("----------------------------");
-			}				
+			new UpdateChecker(this).fetch();
 		}
 	}
 	

--- a/src/main/java/me/clip/deluxetags/updater/UpdateChecker.java
+++ b/src/main/java/me/clip/deluxetags/updater/UpdateChecker.java
@@ -1,8 +1,11 @@
 package me.clip.deluxetags.updater;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.util.Arrays;
 import javax.net.ssl.HttpsURLConnection;
 import me.clip.placeholderapi.util.Msg;
 import org.bukkit.Bukkit;
@@ -14,9 +17,13 @@ import org.bukkit.plugin.Plugin;
 
 public class UpdateChecker implements Listener {
 
-  private final int RESOURCE_ID = 4390;
-  private Plugin plugin;
-  private String spigotVersion, pluginVersion;
+  private static final String MODRINTH_URL =
+      "https://api.modrinth.com/v2/project/wtpLgugo/version?include_changelog=false";
+  private static final String MODRINTH_PAGE = "https://modrinth.com/plugin/deluxetags";
+
+  private final Plugin plugin;
+  private final String pluginVersion;
+  private String modrinthVersion;
   private boolean updateAvailable;
 
   public UpdateChecker(Plugin instance) {
@@ -28,66 +35,112 @@ public class UpdateChecker implements Listener {
     return updateAvailable;
   }
 
-  public String getSpigotVersion() {
-    return spigotVersion;
+  public String getModrinthVersion() {
+    return modrinthVersion;
   }
 
   public void fetch() {
     Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
       try {
-        HttpsURLConnection con = (HttpsURLConnection) new URL(
-            "https://api.spigotmc.org/legacy/update.php?resource=" + RESOURCE_ID).openConnection();
+        HttpsURLConnection con = (HttpsURLConnection) new URL(MODRINTH_URL).openConnection();
         con.setRequestMethod("GET");
-        spigotVersion = new BufferedReader(new InputStreamReader(con.getInputStream())).readLine();
+        con.setRequestProperty("User-Agent", "DeluxeTags/" + pluginVersion);
+
+        JsonElement json = new Gson().fromJson(
+            new BufferedReader(new InputStreamReader(con.getInputStream())),
+            JsonElement.class
+        );
+
+        modrinthVersion = json.getAsJsonArray()
+            .get(0)
+            .getAsJsonObject()
+            .get("version_number")
+            .getAsString();
       } catch (Exception ex) {
-        plugin.getLogger().info("Failed to check for updates on spigot.");
+        plugin.getLogger().info("Failed to check for updates on Modrinth.");
         return;
       }
 
-      if (spigotVersion == null || spigotVersion.isEmpty()) {
+      if (modrinthVersion == null || modrinthVersion.isEmpty()) {
         return;
       }
 
-      updateAvailable = spigotIsNewer();
-
-      if (!updateAvailable) {
-        return;
-      }
+      updateAvailable = modrinthIsNewer();
 
       Bukkit.getScheduler().runTask(plugin, () -> {
-        plugin.getLogger()
-            .info("An update for DeluxeTags (v" + getSpigotVersion() + ") is available at:");
-        plugin.getLogger()
-            .info("https://www.spigotmc.org/resources/deluxetags." + RESOURCE_ID + "/");
-        Bukkit.getPluginManager().registerEvents(this, plugin);
+        logUpdateStatus();
+
+        if (updateAvailable) {
+          Bukkit.getPluginManager().registerEvents(this, plugin);
+        }
       });
     });
   }
 
-  private boolean spigotIsNewer() {
-      if (spigotVersion == null || spigotVersion.isEmpty()) {
-          return false;
-      }
-    String plV = toReadable(pluginVersion);
-    String spV = toReadable(spigotVersion);
-    return plV.compareTo(spV) < 0;
+  private void logUpdateStatus() {
+    plugin.getLogger().info("----------------------------");
+    plugin.getLogger().info("     DeluxeTags Updater");
+    plugin.getLogger().info(" ");
+
+    if (updateAvailable) {
+      plugin.getLogger().info("An update for DeluxeTags has been found!");
+      plugin.getLogger().info("DeluxeTags " + getModrinthVersion());
+      plugin.getLogger().info("You are running " + pluginVersion);
+      plugin.getLogger().info(" ");
+      plugin.getLogger().info("Download at " + MODRINTH_PAGE);
+    } else {
+      plugin.getLogger().info("You are running " + pluginVersion);
+      plugin.getLogger().info("The latest version");
+      plugin.getLogger().info("of DeluxeTags!");
+    }
+
+    plugin.getLogger().info(" ");
+    plugin.getLogger().info("----------------------------");
   }
 
-  private String toReadable(String version) {
-    if (version.contains("-DEV-")) {
-      version = version.split("-DEV-")[0];
+  private boolean modrinthIsNewer() {
+    if (modrinthVersion == null || modrinthVersion.isEmpty()) {
+      return false;
     }
-    return version.replaceAll("\\.", "");
+
+    int[] local = toReadable(pluginVersion);
+    int[] remote = toReadable(modrinthVersion);
+
+    int max = Math.max(local.length, remote.length);
+    for (int i = 0; i < max; i++) {
+      int localPart = i < local.length ? local[i] : 0;
+      int remotePart = i < remote.length ? remote[i] : 0;
+
+      if (localPart < remotePart) {
+        return true;
+      }
+
+      if (localPart > remotePart) {
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  private int[] toReadable(String version) {
+    if (version.contains("-DEV")) {
+      version = version.split("-DEV")[0];
+    }
+
+    return Arrays.stream(version.split("\\."))
+        .map(part -> part.replaceAll("[^0-9]", ""))
+        .filter(part -> !part.isEmpty())
+        .mapToInt(Integer::parseInt)
+        .toArray();
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onJoin(PlayerJoinEvent e) {
     if (e.getPlayer().hasPermission("deluxetags.updates")) {
       Msg.msg(e.getPlayer(),
-          "&bAn update for &5&lDeluxeTags &e(&5&lDeluxeTags &fv" + getSpigotVersion()
-              + "&e)"
-          , "&bis available at &ehttps://www.spigotmc.org/resources/deluxetags." + RESOURCE_ID
-              + "/");
+          "&bAn update for &5&lDeluxeTags &e(&5&lDeluxeTags &fv" + getModrinthVersion() + "&e)",
+          "&bis available at &e" + MODRINTH_PAGE);
     }
   }
 }


### PR DESCRIPTION
This pull request updates the plugin's update checking system to use Modrinth instead of Spigot for version checks, and refactors the related code for clarity and maintainability. The update process now fetches version information from Modrinth's API, compares versions more robustly, and provides improved logging and user notifications.

**Update source migration and refactor:**

* Changed the update check source from Spigot to Modrinth, including new API endpoints and download links in `UpdateChecker.java`. [[1]](diffhunk://#diff-67a7c42b35668a8f16a8e50a00d89633ace6bcca60e186c8a90166c61ba6129eL17-R26) [[2]](diffhunk://#diff-67a7c42b35668a8f16a8e50a00d89633ace6bcca60e186c8a90166c61ba6129eL31-R143)
* Refactored version comparison logic to more accurately handle semantic versioning using integer arrays, improving reliability of update detection.
* Consolidated and improved logging for update status, providing clearer messages for both available and unavailable updates.
* Updated the player join notification to reference Modrinth instead of Spigot, ensuring users receive the correct update link.

**Code cleanup:**

* Simplified the update check flow in `DeluxeTags.java` by removing redundant logging logic and delegating all logging to `UpdateChecker`.


# Updated Output:

```
[14:18:52 INFO]: [DeluxeTags] ----------------------------
[14:18:52 INFO]: [DeluxeTags]      DeluxeTags Updater
[14:18:52 INFO]: [DeluxeTags]
[14:18:52 INFO]: [DeluxeTags] An update for DeluxeTags has been found!
[14:18:52 INFO]: [DeluxeTags] DeluxeTags 1.8.3
[14:18:52 INFO]: [DeluxeTags] You are running 1.7.0-DEV-LOCAL
[14:18:52 INFO]: [DeluxeTags]
[14:18:52 INFO]: [DeluxeTags] Download at https://modrinth.com/plugin/deluxetags
[14:18:52 INFO]: [DeluxeTags]
[14:18:52 INFO]: [DeluxeTags] ----------------------------
```

Closes #37 